### PR TITLE
Add permission configs

### DIFF
--- a/conf/cmi/user.role.anonymous.yml
+++ b/conf/cmi/user.role.anonymous.yml
@@ -16,6 +16,7 @@ dependencies:
     - node
     - paragraphs
     - paragraphs_type_permissions
+    - subrequests
     - system
     - taxonomy
 _core:
@@ -31,6 +32,7 @@ permissions:
   - 'access taxonomy overview'
   - 'administer menu'
   - 'administer taxonomy_term display'
+  - 'issue subrequests'
   - 'translate any entity'
   - 'translate paragraph'
   - 'view all media revisions'


### PR DESCRIPTION
Assign the Issue subrequests permission to the Anonymous user role:

We do this because during the build phase, most of the requests for pages are anonymous requests. By assigning this permission, you can significantly decrease your site's build time.
https://next-drupal.org/docs/upgrade-guide