### PR TITLE
THF-182: THF-182: Updated default metatag tokens.

### DIFF
--- a/conf/cmi/metatag.metatag_defaults.node.yml
+++ b/conf/cmi/metatag.metatag_defaults.node.yml
@@ -7,6 +7,6 @@ _core:
 id: node
 label: Content
 tags:
-  title: '[node:title] | [site:name]'
-  description: '[node:summary]'
+  description: '[node:field_lead_in]'
   canonical_url: '[node:url]'
+  title: '[node:title]'


### PR DESCRIPTION
- Use `Lead-in` field as default for description.
- Site name to the title comes from NextJS