### PR TITLE
THF-32: broken node links

### DIFF
--- a/conf/cmi/jsonapi_extras.jsonapi_resource_config.paragraph--accordion.yml
+++ b/conf/cmi/jsonapi_extras.jsonapi_resource_config.paragraph--accordion.yml
@@ -150,7 +150,7 @@ resourceFields:
     fieldName: field_accordion_text
     publicName: field_accordion_text
     enhancer:
-      id: ''
+      id: text_field_enhancer
   field_accordion_title:
     disabled: false
     fieldName: field_accordion_title
@@ -161,5 +161,11 @@ resourceFields:
     disabled: false
     fieldName: field_accordion_title_level
     publicName: field_accordion_title_level
+    enhancer:
+      id: ''
+  field_accordion_type:
+    disabled: false
+    fieldName: field_accordion_type
+    publicName: field_accordion_type
     enhancer:
       id: ''

--- a/conf/cmi/jsonapi_extras.jsonapi_resource_config.paragraph--banner.yml
+++ b/conf/cmi/jsonapi_extras.jsonapi_resource_config.paragraph--banner.yml
@@ -1,20 +1,18 @@
-uuid: 709636b0-fa31-4a0c-b4db-82263cc9405e
+uuid: 8f08f7fc-f6d4-4b25-830d-0540fc3b4aa2
 langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.text
+    - paragraphs.paragraphs_type.banner
   module:
     - jsonapi_defaults
 third_party_settings:
   jsonapi_defaults:
-    default_include:
-      - field_text
     page_limit: 50
-id: paragraph--text
+id: paragraph--banner
 disabled: false
-path: paragraph/text
-resourceType: paragraph--text
+path: paragraph/banner
+resourceType: paragraph--banner
 resourceFields:
   id:
     disabled: false
@@ -118,9 +116,45 @@ resourceFields:
     publicName: content_translation_changed
     enhancer:
       id: ''
-  field_text:
+  field_background_color:
     disabled: false
-    fieldName: field_text
-    publicName: field_text
+    fieldName: field_background_color
+    publicName: field_background_color
+    enhancer:
+      id: ''
+  field_banner_desc:
+    disabled: false
+    fieldName: field_banner_desc
+    publicName: field_banner_desc
     enhancer:
       id: text_field_enhancer
+  field_banner_design:
+    disabled: false
+    fieldName: field_banner_design
+    publicName: field_banner_design
+    enhancer:
+      id: ''
+  field_banner_link:
+    disabled: false
+    fieldName: field_banner_link
+    publicName: field_banner_link
+    enhancer:
+      id: ''
+  field_banner_link_design:
+    disabled: false
+    fieldName: field_banner_link_design
+    publicName: field_banner_link_design
+    enhancer:
+      id: ''
+  field_banner_title:
+    disabled: false
+    fieldName: field_banner_title
+    publicName: field_banner_title
+    enhancer:
+      id: ''
+  field_icon:
+    disabled: false
+    fieldName: field_icon
+    publicName: field_icon
+    enhancer:
+      id: ''

--- a/conf/cmi/jsonapi_extras.jsonapi_resource_config.paragraph--events_list.yml
+++ b/conf/cmi/jsonapi_extras.jsonapi_resource_config.paragraph--events_list.yml
@@ -1,20 +1,18 @@
-uuid: 709636b0-fa31-4a0c-b4db-82263cc9405e
+uuid: 95e37fcf-6e66-4fd4-9a70-fab56731832e
 langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.text
+    - paragraphs.paragraphs_type.events_list
   module:
     - jsonapi_defaults
 third_party_settings:
   jsonapi_defaults:
-    default_include:
-      - field_text
     page_limit: 50
-id: paragraph--text
+id: paragraph--events_list
 disabled: false
-path: paragraph/text
-resourceType: paragraph--text
+path: paragraph/events_list
+resourceType: paragraph--events_list
 resourceFields:
   id:
     disabled: false
@@ -118,9 +116,33 @@ resourceFields:
     publicName: content_translation_changed
     enhancer:
       id: ''
-  field_text:
+  field_background_color:
     disabled: false
-    fieldName: field_text
-    publicName: field_text
+    fieldName: field_background_color
+    publicName: field_background_color
+    enhancer:
+      id: ''
+  field_event_tag_filter:
+    disabled: false
+    fieldName: field_event_tag_filter
+    publicName: field_event_tag_filter
+    enhancer:
+      id: ''
+  field_events_list_desc:
+    disabled: false
+    fieldName: field_events_list_desc
+    publicName: field_events_list_desc
     enhancer:
       id: text_field_enhancer
+  field_events_list_short:
+    disabled: false
+    fieldName: field_events_list_short
+    publicName: field_events_list_short
+    enhancer:
+      id: ''
+  field_title:
+    disabled: false
+    fieldName: field_title
+    publicName: field_title
+    enhancer:
+      id: ''

--- a/conf/cmi/jsonapi_extras.jsonapi_resource_config.paragraph--liftup_with_image.yml
+++ b/conf/cmi/jsonapi_extras.jsonapi_resource_config.paragraph--liftup_with_image.yml
@@ -1,20 +1,18 @@
-uuid: 709636b0-fa31-4a0c-b4db-82263cc9405e
+uuid: 139407ca-7ecd-4e8d-8b8e-f0502d643efc
 langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.text
+    - paragraphs.paragraphs_type.liftup_with_image
   module:
     - jsonapi_defaults
 third_party_settings:
   jsonapi_defaults:
-    default_include:
-      - field_text
     page_limit: 50
-id: paragraph--text
+id: paragraph--liftup_with_image
 disabled: false
-path: paragraph/text
-resourceType: paragraph--text
+path: paragraph/liftup_with_image
+resourceType: paragraph--liftup_with_image
 resourceFields:
   id:
     disabled: false
@@ -118,9 +116,27 @@ resourceFields:
     publicName: content_translation_changed
     enhancer:
       id: ''
-  field_text:
+  field_liftup_with_image_desc:
     disabled: false
-    fieldName: field_text
-    publicName: field_text
+    fieldName: field_liftup_with_image_desc
+    publicName: field_liftup_with_image_desc
     enhancer:
       id: text_field_enhancer
+  field_liftup_with_image_design:
+    disabled: false
+    fieldName: field_liftup_with_image_design
+    publicName: field_liftup_with_image_design
+    enhancer:
+      id: ''
+  field_liftup_with_image_image:
+    disabled: false
+    fieldName: field_liftup_with_image_image
+    publicName: field_liftup_with_image_image
+    enhancer:
+      id: ''
+  field_liftup_with_image_title:
+    disabled: false
+    fieldName: field_liftup_with_image_title
+    publicName: field_liftup_with_image_title
+    enhancer:
+      id: ''

--- a/conf/cmi/jsonapi_extras.jsonapi_resource_config.paragraph--news_list.yml
+++ b/conf/cmi/jsonapi_extras.jsonapi_resource_config.paragraph--news_list.yml
@@ -1,20 +1,18 @@
-uuid: 709636b0-fa31-4a0c-b4db-82263cc9405e
+uuid: 3f31df57-1aea-4aa0-9c6c-5da78a32a236
 langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.text
+    - paragraphs.paragraphs_type.news_list
   module:
     - jsonapi_defaults
 third_party_settings:
   jsonapi_defaults:
-    default_include:
-      - field_text
     page_limit: 50
-id: paragraph--text
+id: paragraph--news_list
 disabled: false
-path: paragraph/text
-resourceType: paragraph--text
+path: paragraph/news_list
+resourceType: paragraph--news_list
 resourceFields:
   id:
     disabled: false
@@ -118,9 +116,33 @@ resourceFields:
     publicName: content_translation_changed
     enhancer:
       id: ''
-  field_text:
+  field_background_color:
     disabled: false
-    fieldName: field_text
-    publicName: field_text
+    fieldName: field_background_color
+    publicName: field_background_color
+    enhancer:
+      id: ''
+  field_koro:
+    disabled: false
+    fieldName: field_koro
+    publicName: field_koro
+    enhancer:
+      id: ''
+  field_news_list_desc:
+    disabled: false
+    fieldName: field_news_list_desc
+    publicName: field_news_list_desc
     enhancer:
       id: text_field_enhancer
+  field_short_list:
+    disabled: false
+    fieldName: field_short_list
+    publicName: field_short_list
+    enhancer:
+      id: ''
+  field_title:
+    disabled: false
+    fieldName: field_title
+    publicName: field_title
+    enhancer:
+      id: ''

--- a/conf/cmi/jsonapi_extras.jsonapi_resource_config.paragraph--notification.yml
+++ b/conf/cmi/jsonapi_extras.jsonapi_resource_config.paragraph--notification.yml
@@ -1,20 +1,18 @@
-uuid: 709636b0-fa31-4a0c-b4db-82263cc9405e
+uuid: 3318c118-9de4-4dbf-b75f-189bc650eca8
 langcode: en
 status: true
 dependencies:
   config:
-    - paragraphs.paragraphs_type.text
+    - paragraphs.paragraphs_type.notification
   module:
     - jsonapi_defaults
 third_party_settings:
   jsonapi_defaults:
-    default_include:
-      - field_text
     page_limit: 50
-id: paragraph--text
+id: paragraph--notification
 disabled: false
-path: paragraph/text
-resourceType: paragraph--text
+path: paragraph/notification
+resourceType: paragraph--notification
 resourceFields:
   id:
     disabled: false
@@ -118,9 +116,15 @@ resourceFields:
     publicName: content_translation_changed
     enhancer:
       id: ''
-  field_text:
+  field_notification_description:
     disabled: false
-    fieldName: field_text
-    publicName: field_text
+    fieldName: field_notification_description
+    publicName: field_notification_description
     enhancer:
       id: text_field_enhancer
+  field_notification_title:
+    disabled: false
+    fieldName: field_notification_title
+    publicName: field_notification_title
+    enhancer:
+      id: ''

--- a/public/modules/custom/tyollisyyspalvelut_common/src/Plugin/jsonapi/FieldEnhancer/TextFieldEnhancer.php
+++ b/public/modules/custom/tyollisyyspalvelut_common/src/Plugin/jsonapi/FieldEnhancer/TextFieldEnhancer.php
@@ -1,0 +1,143 @@
+<?php
+
+namespace Drupal\tyollisyyspalvelut_common\Plugin\jsonapi\FieldEnhancer;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\jsonapi_extras\Plugin\ResourceFieldEnhancerBase;
+use Shaper\Util\Context;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\path_alias\AliasManagerInterface;
+use DOMDocument;
+use DOMXPath;
+use Symfony\Component\HttpFoundation\Request;
+use Drupal\Core\Language\LanguageManager;
+
+/**
+ * Change internal links to URL aliases in text fields.
+ *
+ * @ResourceFieldEnhancer(
+ *   id = "text_field_enhancer",
+ *   label = @Translation("Text field (Links to URL aliases"),
+ *   description = @Translation("Use Text enhancer for text field with links")
+ * )
+ */
+class TextFieldEnhancer extends ResourceFieldEnhancerBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The alias manager.
+   *
+   * @var \Drupal\path_alias\AliasManagerInterface
+   */
+  protected $aliasManager;
+
+  /**
+   * The language manager.
+   *
+   * @var \Drupal\Core\Language\LanguageManager
+   */
+  protected $languageManager;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function __construct(array $configuration, $plugin_id, array $plugin_definition, EntityTypeManagerInterface $entity_type_manager, AliasManagerInterface $aliasManager, LanguageManager $language_manager, Request $request) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->entityTypeManager = $entity_type_manager;
+    $this->aliasManager = $aliasManager;
+    $this->languageManager = $language_manager;
+    $this->request = $request;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('path_alias.manager'),
+      $container->get('language_manager'),
+      $container->get('request_stack')->getCurrentRequest()
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doUndoTransform($data, Context $context) {
+    $doc = new DOMDocument();
+    $splittedURL = explode('/', $this->request->getRequestUri());
+
+    $siteLangcodes = $this->languageManager->getLanguages();
+    $siteLangcodesList = array_keys($siteLangcodes);
+
+    if (isset($data['value'])) {
+      $doc->loadHTML($data['value']);
+      $xpath = new DOMXPath($doc);
+      $nodeList = $xpath->query('//a/@href');
+      if ($nodeList) {
+        for ($i = 0; $i < $nodeList->length; $i++) {
+          if (str_starts_with($nodeList->item($i)->value, '/node/')) {
+
+            if (in_array($splittedURL[1], $siteLangcodesList)) {
+              $alias = '/' . $splittedURL[1] . $this->aliasManager->getAliasByPath($nodeList->item($i)->value);
+            } else {
+              $alias = $this->aliasManager->getAliasByPath($nodeList->item($i)->value);
+            }
+
+            $data['value'] = str_replace($nodeList->item($i)->value, $alias, $data['value']);
+          }
+        }
+      }
+    }
+
+    if (isset($data['processed'])) {
+      $doc->loadHTML($data['processed']);
+      $processedXpath = new DOMXPath($doc);
+      $nodeList2 = $processedXpath->query('//a/@href');
+      if ($nodeList2) {
+        for ($i = 0; $i < $nodeList2->length; $i++) {
+          if (str_starts_with($nodeList2->item($i)->value, '/node/')) {
+
+            if (in_array($splittedURL[1], $siteLangcodesList)) {
+              $alias2 = '/' . $splittedURL[1] . $this->aliasManager->getAliasByPath($nodeList2->item($i)->value);
+            } else {
+              $alias2 = $this->aliasManager->getAliasByPath($nodeList2->item($i)->value);
+            }
+
+            $data['processed'] = str_replace($nodeList2->item($i)->value, $alias2, $data['processed']);
+          }
+        }
+      }
+    }
+
+    return $data;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function doTransform($value, Context $context) {
+    return $value;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getOutputJsonSchema() {
+    return [
+      'type' => 'object',
+    ];
+  }
+
+}


### PR DESCRIPTION
Add JSON:API text field enhancer plugin for changing internal node links to URL aliases in text fields.
Add field enhancer for needed fields in JSON:API

**How to test**
```
git checkout
drush cim
drush cr
```
Check that links that showed previously /node/1234 url show now url alias. Example links can be found from here: https://helsinkisolutionoffice.atlassian.net/browse/THF-320?atlOrigin=eyJpIjoiMWFiNTkzOTBkYmVlNDc1MGI1NWExYWIyOTA5NWVkMWEiLCJwIjoiaiJ9 