### PR TITLE
THF-468: THF-468: change to tpr_content

### DIFF
--- a/conf/cmi/editor.editor.basic_html.yml
+++ b/conf/cmi/editor.editor.basic_html.yml
@@ -50,7 +50,7 @@ settings:
   plugins:
     drupallink:
       linkit_enabled: true
-      linkit_profile: helfi
+      linkit_profile: tpr_content
 image_upload:
   status: true
   scheme: public

--- a/public/modules/custom/tyollisyyspalvelut_common/css/ckeditor.css
+++ b/public/modules/custom/tyollisyyspalvelut_common/css/ckeditor.css
@@ -33,7 +33,7 @@ h6 {
 
 a[data-is-external="true"],
 a[data-entity-type="node"],
-a[data-entity-type="tpr_unit"]::after {
+a[data-entity-type="tpr_unit"] {
   display: inline-flex;
 }
 

--- a/public/modules/custom/tyollisyyspalvelut_common/css/ckeditor.css
+++ b/public/modules/custom/tyollisyyspalvelut_common/css/ckeditor.css
@@ -32,18 +32,21 @@ h6 {
 }
 
 a[data-is-external="true"],
-a[data-entity-type="node"] {
+a[data-entity-type="node"],
+a[data-entity-type="tpr_unit"]::after {
   display: inline-flex;
 }
 
 a[data-is-external="true"]::after,
-a[data-entity-type="node"]::after {
+a[data-entity-type="node"]::after,
+a[data-entity-type="tpr_unit"]::after {
   content: '';
   margin-left: 4px;
   width: 1.25rem;
 }
 
-a[data-entity-type="node"]::after {
+a[data-entity-type="node"]::after,
+a[data-entity-type="tpr_unit"]::after {
   margin-right: 8px;
   background: url('../assets/arrow-right.svg') no-repeat center center;
 }


### PR DESCRIPTION
Changed ckEditor to use tpr_content as link profile and added styling to data-entity-type="tpr_unit" as it is with data-entity-type="node". It should follow the same roles as internall node links.

How to test:
start ui with the project `THF-468-TPR-links-ui`
- `make shell`
- `drush cim -y`
- `drush cr`
- Create new basic page and add text paragraph
- Add link to the editor with some office, example kamppi https://drupal-tyollisyyspalvelut-helfi.docker.so/node/add/page
- Link should have arrow after the link text in the ckEditor

<img width="371" alt="Screenshot 2023-03-08 at 13 20 29" src="https://user-images.githubusercontent.com/42113018/223700354-ed771389-6581-4852-a44d-8bb991f3d9de.png">
