### PR TITLE
Thf 470 linked event tag internet handling

### DIFF
--- a/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
+++ b/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
@@ -291,6 +291,7 @@ class SyncContent extends DrushCommands {
    * @throws \GuzzleHttp\Exception\GuzzleException
    */
   private function nodeAddTranslation($node, $source, $langcode) {
+    /** @var \Drupal\node\Entity\Node $node */
     $node->setTitle($source->name->$langcode ?? $source->name->fi);
     $node->field_location = $source->location->name->$langcode ?? $source->location->name->fi ?? '';
     $node->field_short_description = $source->short_description->$langcode ?? $source->short_description->fi ?? '';
@@ -304,7 +305,12 @@ class SyncContent extends DrushCommands {
     $node->field_tags = $this->getTags($source->keywords, $langcode);
 
     if ($source->location->name->fi === 'Internet') {
-      $node->field_tags = array_push($node->get('field_tags')->value, 'etätapahtuma');
+      $tags = [];
+      foreach ($node->get('field_tags') as $field) {
+        $tags[] = $field->value;
+      }
+      $tags[] = 'etätapahtuma';
+      $node->set('field_tags', $tags);
     }
 
     return $node;


### PR DESCRIPTION
linked even sync didn't work on develop environment because tag handling tried to push array to a string field when the event tag is internet. 
This produced the following error `error: array_push() argument #1 ($array) must be of type array`

How to test:
Run also Next app with branch https://github.com/City-of-Helsinki/employment-services-ui/pull/287
- `make shell`
- `make drush cim -y`
- `make composer install`
-  remove all events `drush edel node --bundle=event` . This is important step to do to make sure you will get needed internet tag to the json.
- check from Drupal that you don't have any events. https://drupal-tyollisyyspalvelut-helfi.docker.so/admin/content?title=&type=event&status=All&langcode=All
- Note you will get following error on local database [error]  GuzzleHttp\Exception\ConnectException: cURL error 7: Failed to connect to localhost port 3000 after 0 ms: 
- run all event again `drush linkedevents:sync`
- Note you will get following error on local database [error]  GuzzleHttp\Exception\ConnectException: cURL error 7: Failed to connect to localhost port 3000 after 0 ms:
- the sync should go now without `error: array_push() argument #1 ($array) must be of type array`. note that in local environment you will get  following errors.
- check from drupal that you have again events. https://drupal-tyollisyyspalvelut-helfi.docker.so/admin/content?title=&type=event&status=All&langcode=All
- Finally run `drush search-api:index`
- You should have new tags on the https://drupal-tyollisyyspalvelut-helfi.docker.so/ajankohtaista/tapahtumat
- make sure you don't have any internet tag.
- make sure you have 'etätapahtuma' tag on the tag list.
<img width="1196" alt="Screenshot 2023-03-13 at 13 38 35" src="https://user-images.githubusercontent.com/42113018/224691490-68f4c83a-a466-468a-b42d-c66c8f711028.png">
