### PR TITLE
Thf 416 linked events info url drupal

### DIFF
--- a/conf/cmi/core.entity_form_display.node.event.default.yml
+++ b/conf/cmi/core.entity_form_display.node.event.default.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.event.field_location
     - field.field.node.event.field_location_extra_info
     - field.field.node.event.field_location_id
+    - field.field.node.event.field_offers_info_url
     - field.field.node.event.field_publisher
     - field.field.node.event.field_short_description
     - field.field.node.event.field_start_time
@@ -141,6 +142,14 @@ content:
     weight: 23
     region: content
     settings:
+      placeholder: ''
+    third_party_settings: {  }
+  field_offers_info_url:
+    type: string_textfield
+    weight: 32
+    region: content
+    settings:
+      size: 60
       placeholder: ''
     third_party_settings: {  }
   field_publisher:

--- a/conf/cmi/core.entity_view_display.node.event.default.yml
+++ b/conf/cmi/core.entity_view_display.node.event.default.yml
@@ -16,6 +16,7 @@ dependencies:
     - field.field.node.event.field_location
     - field.field.node.event.field_location_extra_info
     - field.field.node.event.field_location_id
+    - field.field.node.event.field_offers_info_url
     - field.field.node.event.field_publisher
     - field.field.node.event.field_short_description
     - field.field.node.event.field_start_time
@@ -50,6 +51,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_offers_info_url:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 3
     region: content
   links:
     settings: {  }

--- a/conf/cmi/core.entity_view_display.node.event.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.event.teaser.yml
@@ -17,6 +17,7 @@ dependencies:
     - field.field.node.event.field_location
     - field.field.node.event.field_location_extra_info
     - field.field.node.event.field_location_id
+    - field.field.node.event.field_offers_info_url
     - field.field.node.event.field_publisher
     - field.field.node.event.field_short_description
     - field.field.node.event.field_start_time
@@ -50,6 +51,7 @@ hidden:
   field_location: true
   field_location_extra_info: true
   field_location_id: true
+  field_offers_info_url: true
   field_publisher: true
   field_short_description: true
   field_start_time: true

--- a/conf/cmi/field.field.node.event.field_offers_info_url.yml
+++ b/conf/cmi/field.field.node.event.field_offers_info_url.yml
@@ -9,7 +9,7 @@ id: node.event.field_offers_info_url
 field_name: field_offers_info_url
 entity_type: node
 bundle: event
-label: offers_info_url
+label: 'Offers info url'
 description: ''
 required: false
 translatable: false

--- a/conf/cmi/field.field.node.event.field_offers_info_url.yml
+++ b/conf/cmi/field.field.node.event.field_offers_info_url.yml
@@ -1,0 +1,19 @@
+uuid: 3e865dd4-3844-4eba-b300-be2dc38b943a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_offers_info_url
+    - node.type.event
+id: node.event.field_offers_info_url
+field_name: field_offers_info_url
+entity_type: node
+bundle: event
+label: offers_info_url
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.node.field_offers_info_url.yml
+++ b/conf/cmi/field.storage.node.field_offers_info_url.yml
@@ -1,0 +1,21 @@
+uuid: 6d4091e1-e565-4dae-8cad-fe7e3c40e129
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_offers_info_url
+field_name: field_offers_info_url
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
+++ b/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
@@ -305,7 +305,11 @@ class SyncContent extends DrushCommands {
     $node->field_tags = $this->getTags($source->keywords, $langcode);
 
     foreach ($source->offers as $offer) {
-      $node->field_offers_info_url = isset($offer->info_url->$langcode) && strlen($offer->info_url->$langcode) <= 255 ? $offer->info_url->$langcode : '';
+      // Check the URL is not empty or too long.
+      if (empty($offer->info_url->$langcode) || strlen($offer->info_url->$langcode) > 255) {
+        continue;
+      }
+      $node->field_offers_info_url = $offer->info_url->$langcode;
     }
 
     if ($source->location->name->fi === 'Internet') {

--- a/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
+++ b/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
@@ -300,6 +300,7 @@ class SyncContent extends DrushCommands {
       'format' => 'basic_html',
     ];
     $node->field_info_url = isset($source->info_url->$langcode) && strlen($source->info_url->$langcode) <= 255 ? $source->info_url->$langcode : '';
+    $node->field_offers_info_url = isset($source->offers->info_url->$langcode) && strlen($source->offers->info_url->$langcode) <= 255 ? $source->offers->info_url->$langcode : '';
     $node->field_location_extra_info = $source->location_extra_info->$langcode ?? $source->location_extra_info->fi ?? '';
     $node->field_street_address = $source->location->street_address->$langcode ?? $source->location->street_address->fi ?? '';
     $node->field_tags = $this->getTags($source->keywords, $langcode);

--- a/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
+++ b/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
@@ -300,10 +300,13 @@ class SyncContent extends DrushCommands {
       'format' => 'basic_html',
     ];
     $node->field_info_url = isset($source->info_url->$langcode) && strlen($source->info_url->$langcode) <= 255 ? $source->info_url->$langcode : '';
-    $node->field_offers_info_url = isset($source->offers->info_url->$langcode) && strlen($source->offers->info_url->$langcode) <= 255 ? $source->offers->info_url->$langcode : '';
     $node->field_location_extra_info = $source->location_extra_info->$langcode ?? $source->location_extra_info->fi ?? '';
     $node->field_street_address = $source->location->street_address->$langcode ?? $source->location->street_address->fi ?? '';
     $node->field_tags = $this->getTags($source->keywords, $langcode);
+
+    foreach ($source->offers as $offer) {
+      $node->field_offers_info_url = isset($offer->info_url->$langcode) && strlen($offer->info_url->$langcode) <= 255 ? $offer->info_url->$langcode : '';
+    }
 
     if ($source->location->name->fi === 'Internet') {
       $tags = [];


### PR DESCRIPTION
Created field_offers_info_url to bring event sing up url from linked event. The offers info url is inside of an array. So we loop the offers to get the url. 

How to test:
This branch need to be tested with branch  https://github.com/City-of-Helsinki/employment-services-ui/pull/290
- `make shell`
- `composer install`
- `drush cim -y; drush cr;`
- sync event`drush linkedevents:sync`
- index event`drush search-api:index`
- go to drupal that you have https://drupal-tyollisyyspalvelut-helfi.docker.so/ajankohtaista/tapahtumat/testitapahtuma 
- The event should have button sing up in ui and it should have new field field_offers_info_url