### PR TITLE
THF-105: LinkedEvents translation support

### DIFF
--- a/conf/cmi/core.base_field_override.node.event.title.yml
+++ b/conf/cmi/core.base_field_override.node.event.title.yml
@@ -11,7 +11,7 @@ bundle: event
 label: Title
 description: ''
 required: true
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/core.entity_form_display.node.event.default.yml
+++ b/conf/cmi/core.entity_form_display.node.event.default.yml
@@ -224,6 +224,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   simple_sitemap:
     weight: 10
     region: content

--- a/conf/cmi/core.entity_form_display.node.event.default.yml
+++ b/conf/cmi/core.entity_form_display.node.event.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.event.field_end_time
     - field.field.node.event.field_event_status
+    - field.field.node.event.field_event_tags
     - field.field.node.event.field_external_links
     - field.field.node.event.field_id
     - field.field.node.event.field_image_alt
@@ -28,7 +29,9 @@ dependencies:
     - hdbt_admin_editorial
     - link
     - path
+    - publication_date
     - scheduler
+    - select2
     - text
 id: node.event.default
 targetEntityType: node
@@ -43,7 +46,7 @@ content:
     third_party_settings: {  }
   field_end_time:
     type: string_textfield
-    weight: 19
+    weight: 20
     region: content
     settings:
       size: 60
@@ -51,15 +54,25 @@ content:
     third_party_settings: {  }
   field_event_status:
     type: string_textfield
-    weight: 17
+    weight: 18
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_event_tags:
+    type: select2_entity_reference
+    weight: 28
+    region: content
+    settings:
+      width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
+    third_party_settings: {  }
   field_external_links:
     type: link_default
-    weight: 28
+    weight: 30
     region: content
     settings:
       placeholder_url: ''
@@ -75,7 +88,7 @@ content:
     third_party_settings: {  }
   field_image_alt:
     type: string_textfield
-    weight: 15
+    weight: 16
     region: content
     settings:
       size: 60
@@ -83,7 +96,7 @@ content:
     third_party_settings: {  }
   field_image_name:
     type: string_textfield
-    weight: 13
+    weight: 14
     region: content
     settings:
       size: 60
@@ -91,7 +104,7 @@ content:
     third_party_settings: {  }
   field_image_url:
     type: string_textfield
-    weight: 14
+    weight: 15
     region: content
     settings:
       size: 60
@@ -99,7 +112,7 @@ content:
     third_party_settings: {  }
   field_in_language:
     type: string_textfield
-    weight: 16
+    weight: 17
     region: content
     settings:
       size: 60
@@ -107,7 +120,7 @@ content:
     third_party_settings: {  }
   field_info_url:
     type: string_textfield
-    weight: 27
+    weight: 29
     region: content
     settings:
       size: 60
@@ -115,7 +128,7 @@ content:
     third_party_settings: {  }
   field_last_modified_time:
     type: string_textfield
-    weight: 20
+    weight: 21
     region: content
     settings:
       size: 60
@@ -123,7 +136,7 @@ content:
     third_party_settings: {  }
   field_location:
     type: string_textfield
-    weight: 21
+    weight: 22
     region: content
     settings:
       size: 60
@@ -131,7 +144,7 @@ content:
     third_party_settings: {  }
   field_location_extra_info:
     type: string_textfield
-    weight: 24
+    weight: 25
     region: content
     settings:
       size: 60
@@ -139,14 +152,14 @@ content:
     third_party_settings: {  }
   field_location_id:
     type: number
-    weight: 23
+    weight: 24
     region: content
     settings:
       placeholder: ''
     third_party_settings: {  }
   field_offers_info_url:
     type: string_textfield
-    weight: 32
+    weight: 34
     region: content
     settings:
       size: 60
@@ -154,7 +167,7 @@ content:
     third_party_settings: {  }
   field_publisher:
     type: string_textfield
-    weight: 25
+    weight: 26
     region: content
     settings:
       size: 60
@@ -162,7 +175,7 @@ content:
     third_party_settings: {  }
   field_short_description:
     type: text_textarea
-    weight: 12
+    weight: 13
     region: content
     settings:
       rows: 5
@@ -170,7 +183,7 @@ content:
     third_party_settings: {  }
   field_start_time:
     type: string_textfield
-    weight: 18
+    weight: 19
     region: content
     settings:
       size: 60
@@ -178,7 +191,7 @@ content:
     third_party_settings: {  }
   field_street_address:
     type: string_textfield
-    weight: 22
+    weight: 23
     region: content
     settings:
       size: 60
@@ -186,7 +199,7 @@ content:
     third_party_settings: {  }
   field_tags:
     type: options_select
-    weight: 26
+    weight: 27
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -220,7 +233,7 @@ content:
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 29
+    weight: 31
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -231,7 +244,7 @@ content:
     settings: {  }
     third_party_settings: {  }
   simple_sitemap:
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -258,7 +271,7 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -274,12 +287,12 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 30
+    weight: 32
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 31
+    weight: 33
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_form_display.taxonomy_term.event_tags.default.yml
+++ b/conf/cmi/core.entity_form_display.taxonomy_term.event_tags.default.yml
@@ -1,0 +1,65 @@
+uuid: c67c2d9b-e044-4f99-9e1d-ca2feb8fb4c9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.event_tags.field_id
+    - taxonomy.vocabulary.event_tags
+  module:
+    - path
+    - text
+id: taxonomy_term.event_tags.default
+targetEntityType: taxonomy_term
+bundle: event_tags
+mode: default
+content:
+  description:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_id:
+    type: string_textfield
+    weight: 101
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 100
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/conf/cmi/core.entity_view_display.node.event.default.yml
+++ b/conf/cmi/core.entity_view_display.node.event.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.event.field_end_time
     - field.field.node.event.field_event_status
+    - field.field.node.event.field_event_tags
     - field.field.node.event.field_external_links
     - field.field.node.event.field_id
     - field.field.node.event.field_image_alt
@@ -68,6 +69,7 @@ content:
 hidden:
   field_end_time: true
   field_event_status: true
+  field_event_tags: true
   field_id: true
   field_image_alt: true
   field_image_name: true

--- a/conf/cmi/core.entity_view_display.node.event.default.yml
+++ b/conf/cmi/core.entity_view_display.node.event.default.yml
@@ -84,5 +84,6 @@ hidden:
   field_tags: true
   field_text: true
   langcode: true
+  published_at: true
   search_api_excerpt: true
   toc_enabled: true

--- a/conf/cmi/core.entity_view_display.node.event.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.event.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.event.field_end_time
     - field.field.node.event.field_event_status
+    - field.field.node.event.field_event_tags
     - field.field.node.event.field_external_links
     - field.field.node.event.field_id
     - field.field.node.event.field_image_alt
@@ -40,6 +41,7 @@ content:
 hidden:
   field_end_time: true
   field_event_status: true
+  field_event_tags: true
   field_external_links: true
   field_id: true
   field_image_alt: true

--- a/conf/cmi/core.entity_view_display.node.event.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.event.teaser.yml
@@ -59,5 +59,6 @@ hidden:
   field_tags: true
   field_text: true
   langcode: true
+  published_at: true
   search_api_excerpt: true
   toc_enabled: true

--- a/conf/cmi/core.entity_view_display.taxonomy_term.event_tags.default.yml
+++ b/conf/cmi/core.entity_view_display.taxonomy_term.event_tags.default.yml
@@ -1,0 +1,32 @@
+uuid: 0aa0ff6e-32b5-4165-b9ea-6502a165674b
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.event_tags.field_id
+    - taxonomy.vocabulary.event_tags
+  module:
+    - text
+id: taxonomy_term.event_tags.default
+targetEntityType: taxonomy_term
+bundle: event_tags
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/conf/cmi/field.field.node.event.field_event_tags.yml
+++ b/conf/cmi/field.field.node.event.field_event_tags.yml
@@ -1,0 +1,29 @@
+uuid: d1455b51-dace-486d-81e0-8f3b645ea995
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_event_tags
+    - node.type.event
+    - taxonomy.vocabulary.event_tags
+id: node.event.field_event_tags
+field_name: field_event_tags
+entity_type: node
+bundle: event
+label: 'Event tags'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      event_tags: event_tags
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/cmi/field.field.node.event.field_in_language.yml
+++ b/conf/cmi/field.field.node.event.field_in_language.yml
@@ -12,7 +12,7 @@ bundle: event
 label: 'in language'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.node.event.field_info_url.yml
+++ b/conf/cmi/field.field.node.event.field_info_url.yml
@@ -12,7 +12,7 @@ bundle: event
 label: 'Info url'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.node.event.field_location.yml
+++ b/conf/cmi/field.field.node.event.field_location.yml
@@ -12,7 +12,7 @@ bundle: event
 label: Location
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.node.event.field_location_extra_info.yml
+++ b/conf/cmi/field.field.node.event.field_location_extra_info.yml
@@ -12,7 +12,7 @@ bundle: event
 label: 'Location extra info'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.node.event.field_offers_info_url.yml
+++ b/conf/cmi/field.field.node.event.field_offers_info_url.yml
@@ -12,7 +12,7 @@ bundle: event
 label: 'Offers info url'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.node.event.field_short_description.yml
+++ b/conf/cmi/field.field.node.event.field_short_description.yml
@@ -14,7 +14,7 @@ bundle: event
 label: 'short description'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.node.event.field_street_address.yml
+++ b/conf/cmi/field.field.node.event.field_street_address.yml
@@ -12,7 +12,7 @@ bundle: event
 label: 'Street address'
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.node.event.field_text.yml
+++ b/conf/cmi/field.field.node.event.field_text.yml
@@ -19,7 +19,7 @@ bundle: event
 label: Text
 description: ''
 required: false
-translatable: false
+translatable: true
 default_value: {  }
 default_value_callback: ''
 settings: {  }

--- a/conf/cmi/field.field.taxonomy_term.event_tags.field_id.yml
+++ b/conf/cmi/field.field.taxonomy_term.event_tags.field_id.yml
@@ -1,0 +1,19 @@
+uuid: 6cb9eca4-d812-4082-9efa-bfd1400b571c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_id
+    - taxonomy.vocabulary.event_tags
+id: taxonomy_term.event_tags.field_id
+field_name: field_id
+entity_type: taxonomy_term
+bundle: event_tags
+label: ID
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.node.field_event_tags.yml
+++ b/conf/cmi/field.storage.node.field_event_tags.yml
@@ -1,0 +1,20 @@
+uuid: 4a02f650-2327-439e-9a2c-1893a2880b7b
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_event_tags
+field_name: field_event_tags
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.taxonomy_term.field_id.yml
+++ b/conf/cmi/field.storage.taxonomy_term.field_id.yml
@@ -1,0 +1,21 @@
+uuid: 5d117ae0-3977-4c3f-acd4-c7faf4259398
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_id
+field_name: field_id
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language.content_settings.taxonomy_term.event_tags.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.event_tags.yml
@@ -1,18 +1,16 @@
-uuid: 3a63399a-b0ae-45df-9328-f26fb04aefc4
+uuid: 43d26305-7d63-47c4-9723-05873883c89e
 langcode: en
 status: true
 dependencies:
   config:
-    - taxonomy.vocabulary.search_keywords
+    - taxonomy.vocabulary.event_tags
   module:
     - content_translation
 third_party_settings:
   content_translation:
     enabled: true
-    bundle_settings:
-      untranslatable_fields_hide: '0'
-id: taxonomy_term.search_keywords
+id: taxonomy_term.event_tags
 target_entity_type_id: taxonomy_term
-target_bundle: search_keywords
+target_bundle: event_tags
 default_langcode: site_default
 language_alterable: false

--- a/conf/cmi/search_api.index.events_en.yml
+++ b/conf/cmi/search_api.index.events_en.yml
@@ -4,12 +4,13 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_end_time
+    - field.storage.node.field_event_tags
     - field.storage.node.field_id
     - field.storage.node.field_image_alt
     - field.storage.node.field_image_url
-    - field.storage.node.field_short_description
     - field.storage.node.field_location
     - field.storage.node.field_location_extra_info
+    - field.storage.node.field_short_description
     - field.storage.node.field_start_time
     - field.storage.node.field_street_address
     - field.storage.node.field_tags
@@ -17,6 +18,7 @@ dependencies:
     - search_api.server.elastic
   module:
     - node
+    - taxonomy
     - search_api
 id: events_en
 name: 'Events EN'
@@ -35,6 +37,16 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_end_time
+  field_event_tags:
+    label: 'Event tags » Taxonomy term » Name'
+    datasource_id: 'entity:node'
+    property_path: 'field_event_tags:entity:name'
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_event_tags
+      module:
+        - taxonomy
   field_id:
     label: Id
     datasource_id: 'entity:node'
@@ -167,6 +179,7 @@ processor_settings:
     all_fields: true
     fields:
       - entity_type
+      - field_event_tags
       - field_id
       - field_image_alt
       - field_image_url

--- a/conf/cmi/search_api.index.events_fi.yml
+++ b/conf/cmi/search_api.index.events_fi.yml
@@ -5,12 +5,13 @@ dependencies:
   config:
     - field.storage.node.field_end_time
     - field.storage.node.field_event_status
+    - field.storage.node.field_event_tags
     - field.storage.node.field_id
     - field.storage.node.field_image_alt
     - field.storage.node.field_image_url
-    - field.storage.node.field_short_description
     - field.storage.node.field_location
     - field.storage.node.field_location_extra_info
+    - field.storage.node.field_short_description
     - field.storage.node.field_start_time
     - field.storage.node.field_street_address
     - field.storage.node.field_tags
@@ -18,6 +19,7 @@ dependencies:
     - search_api.server.elastic
   module:
     - node
+    - taxonomy
     - search_api
 id: events_fi
 name: 'Events FI'
@@ -44,6 +46,16 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_event_status
+  field_event_tags:
+    label: 'Event tags » Taxonomy term » Name'
+    datasource_id: 'entity:node'
+    property_path: 'field_event_tags:entity:name'
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_event_tags
+      module:
+        - taxonomy
   field_id:
     label: Id
     datasource_id: 'entity:node'
@@ -176,6 +188,8 @@ processor_settings:
     all_fields: true
     fields:
       - entity_type
+      - field_event_status
+      - field_event_tags
       - field_id
       - field_image_alt
       - field_image_url

--- a/conf/cmi/search_api.index.events_sv.yml
+++ b/conf/cmi/search_api.index.events_sv.yml
@@ -4,12 +4,13 @@ status: true
 dependencies:
   config:
     - field.storage.node.field_end_time
+    - field.storage.node.field_event_tags
     - field.storage.node.field_id
     - field.storage.node.field_image_alt
     - field.storage.node.field_image_url
-    - field.storage.node.field_short_description
     - field.storage.node.field_location
     - field.storage.node.field_location_extra_info
+    - field.storage.node.field_short_description
     - field.storage.node.field_start_time
     - field.storage.node.field_street_address
     - field.storage.node.field_tags
@@ -17,6 +18,7 @@ dependencies:
     - search_api.server.elastic
   module:
     - node
+    - taxonomy
     - search_api
 id: events_sv
 name: 'Events SV'
@@ -35,6 +37,16 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_end_time
+  field_event_tags:
+    label: 'Event tags » Taxonomy term » Name'
+    datasource_id: 'entity:node'
+    property_path: 'field_event_tags:entity:name'
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_event_tags
+      module:
+        - taxonomy
   field_id:
     label: Id
     datasource_id: 'entity:node'
@@ -167,6 +179,7 @@ processor_settings:
     all_fields: true
     fields:
       - entity_type
+      - field_event_tags
       - field_id
       - field_image_alt
       - field_image_url

--- a/conf/cmi/taxonomy.vocabulary.event_tags.yml
+++ b/conf/cmi/taxonomy.vocabulary.event_tags.yml
@@ -1,0 +1,8 @@
+uuid: c0acc20d-39a1-4627-a62f-364578895954
+langcode: en
+status: true
+dependencies: {  }
+name: 'Event tags'
+vid: event_tags
+description: ''
+weight: 0

--- a/public/modules/custom/tyollisyyspalvelut_common/tyollisyyspalvelut_common.module
+++ b/public/modules/custom/tyollisyyspalvelut_common/tyollisyyspalvelut_common.module
@@ -8,7 +8,6 @@
 use Drupal\editor\Entity\Editor;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Entity\EntityForm;
-use Drupal\Core\Entity\EntityInterface;
 
 /**
  * @param array $css
@@ -44,31 +43,6 @@ function redirectFunction(array &$form, FormStateInterface $form_state) {
     // Remove destination query string from request.
     \Drupal::request()->query->remove('destination');
     return;
-  }
-}
-
-/**
- * Implements hook_ENTITY_TYPE_insert().
- *
- * Create translations for Event when it's created through JSON:API
- * because JSON:API POST method doesn't allow creating additional translations atm.
- * https://www.drupal.org/docs/core-modules-and-themes/core-modules/jsonapi-module/translations
- */
-function tyollisyyspalvelut_common_node_insert(EntityInterface $entity) {
-  if ($entity->getType() !== 'event') {
-    return;
-  }
-
-  $site_languages = \Drupal::languageManager()->getLanguages();
-  $langcodes = array_keys($site_languages);
-
-  foreach ($langcodes as $lang) {
-    if ($lang === 'fi') {
-      continue;
-    }
-
-    $translated_entity = $entity->addTranslation($lang, $entity->toArray());
-    $translated_entity->save();
   }
 }
 

--- a/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
+++ b/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
@@ -10,6 +10,9 @@ use Drush\Commands\DrushCommands;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\ClientException;
 use Drupal\Core\Utility\Error;
+use Drupal\node\NodeInterface;
+use Drupal\taxonomy\TermInterface;
+use stdClass;
 
 /**
  * SyncContent drush commands.
@@ -52,6 +55,13 @@ class SyncContent extends DrushCommands {
    * @var string
    */
   private string $contentType;
+
+  /**
+   * Term vocabulary.
+   *
+   * @var string
+   */
+  private string $termVocabulary;
 
   /**
    * Used ID to use as content author.
@@ -120,8 +130,22 @@ class SyncContent extends DrushCommands {
     $this->dataChunkSize = 50;
     $this->dataUrl = 'https://api.hel.fi/linkedevents/v1/event/?include=location&publisher=ahjo:u02120030,ahjo:u021200&keyword=yso:p6357&sort=-end_time&page_size='.$this->dataChunkSize;
     $this->contentType = 'event';
+    $this->termVocabulary = 'event_tags';
     $this->userId = 2; // LinkedEvent user
-    $this->allowedTags = ["maahanmuuttajat", "nuoret", "info", "koulutus", "messut", "neuvonta", "rekrytointi", "työpajat", "digitaidot", "etätapahtuma", "palkkatuki", "työnhaku"];
+    $this->allowedTags = [
+      "maahanmuuttajat",
+      "nuoret",
+      "info",
+      "koulutus",
+      "messut",
+      "neuvonta",
+      "rekrytointi",
+      "työpajat",
+      "digitaidot",
+      "etätapahtuma",
+      "palkkatuki",
+      "työnhaku"
+    ];
     $this->processLog = ['new' => 0, 'updated' => 0, 'deleted' => 0];
     $this->languages = \Drupal::languageManager()->getLanguages();
     $this->entityTypeManager = $entityTypeManager;
@@ -241,12 +265,15 @@ class SyncContent extends DrushCommands {
       // Create original node with default fields and default language.
       $node = $this->nodeAddDefaults($node, $item);
       $node = $this->nodeAddTranslation($node, $item, 'fi');
+
+      // Add keywords as taxonomy terms, along with translations.
+      $node = $this->nodeAddTaxonomyTerms($node, $item);
+
       // Update process log.
       $node->isNew() ? $this->processLog['new']++ : $this->processLog['updated']++;
       // Save the node.
       $node->save();
 
-      /** @var \Drupal\node\Entity\Node $node */
       foreach ($this->languages as $langcode => $language) {
         if ($langcode === 'fi') {
           continue;
@@ -273,9 +300,9 @@ class SyncContent extends DrushCommands {
    * @param $node
    * @param $source
    *
-   * @return \Drupal\Core\Entity\EntityInterface
+   * @return \Drupal\node\NodeInterface
    */
-  private function nodeAddDefaults($node, $source): EntityInterface {
+  private function nodeAddDefaults(NodeInterface $node, $source): NodeInterface {
     $node->field_image_name = count($source->images) > 0 ? $source->images[0]->name : '';
     $node->field_image_url = count($source->images) > 0 ? $source->images[0]->url : '';
     $node->field_image_alt = count($source->images) > 0 ? $source->images[0]->alt_text : '';
@@ -290,16 +317,63 @@ class SyncContent extends DrushCommands {
   }
 
   /**
-   * Populate translatable fields with values.
+   * Add keywords and their translations to node as taxonomy terms.
    *
-   * @param $node
-   * @param $source
-   * @param $langcode
+   * @param \Drupal\node\NodeInterface $node
+   *   Node to edit.
+   * @param \stdClass $source
+   *   Entity source from API.
    *
-   * @return mixed
-   * @throws \GuzzleHttp\Exception\GuzzleException
+   * @return \Drupal\node\NodeInterface
+   *   Node with taxonomy terms added.
    */
-  private function nodeAddTranslation($node, $source, $langcode) {
+  private function nodeAddTaxonomyTerms(NodeInterface $node, \stdClass $source): NodeInterface {
+    $tids = [];
+    foreach ($source->keywords as $keyword) {
+      $data = $this->fetch($keyword->{'@id'});
+      if (!in_array($data->name->fi, $this->allowedTags)) {
+        continue;
+      }
+
+      $term = $this->termInit($data);
+      $term->save();
+
+      foreach ($this->languages as $langcode => $language) {
+        if ($langcode === 'fi') {
+          continue;
+        }
+        $this->addTermTranslation($term, $data, $langcode);
+      }
+
+      $tids[] = $term->id();
+    }
+
+    if ($source->location->name->fi === 'Internet') {
+      $internet_tag = new stdClass();
+      $internet_tag->name->fi = 'Internet';
+      $internet_tag->id = 'internet';
+      $internet_term = $this->termInit($internet_tag);
+      $tids[] = $internet_term->id();
+    }
+
+    $node->set('field_event_tags', $tids);
+    return $node;
+  }
+
+  /**
+   * Add translation for node.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   Node to add translation for.
+   * @param \stdClass $source
+   *   Entity data from API.
+   * @param string $langcode
+   *   Language code for translation.
+   *
+   * @return \Drupal\node\NodeInterface
+   *   Translated version of node.
+   */
+  private function nodeAddTranslation(NodeInterface $node, \stdClass $source, string $langcode): NodeInterface {
     /** @var \Drupal\node\Entity\Node $node */
     $node->setTitle($source->name->$langcode ?? $source->name->fi);
     $node->field_location = $source->location->name->$langcode ?? $source->location->name->fi ?? '';
@@ -323,6 +397,8 @@ class SyncContent extends DrushCommands {
       $node->field_offers_info_url = $offer->info_url->$langcode;
     }
 
+    // @todo Legacy version of tag implementation.
+    // this should be removed when new version is approved.
     if ($source->location->name->fi === 'Internet') {
       $tags = [];
       foreach ($node->get('field_tags') as $field) {
@@ -338,10 +414,13 @@ class SyncContent extends DrushCommands {
   /**
    * Node object initializer.
    *
-   * @return \Drupal\Core\Entity\EntityInterface
+   * @param \stdClass $source
+   *   Entity data from API.
+   *
+   * @return \Drupal\node\NodeInterface
    *   Returns node object.
    */
-  private function nodeInit(\stdClass $source): EntityInterface {
+  private function nodeInit(\stdClass $source): NodeInterface {
     // Build query to fetch existing nodes.
     $query = $this->nodeStorage->getQuery();
     $query->condition('type', $this->contentType);
@@ -365,6 +444,81 @@ class SyncContent extends DrushCommands {
         'field_id' => $source->id,
       ]
     );
+  }
+
+  /**
+   * Taxonomy term object initializer.
+   *
+   * @param \stdClass $source
+   *   Source entity from API.
+   *
+   * @return \Drupal\taxonomy\TermInterface
+   *   Returns taxonomy term object.
+   */
+  private function termInit(\stdClass $source): TermInterface {
+    // Build query to fetch existing nodes.
+    $query = $this->termStorage->getQuery();
+    $query->condition('vid', $this->termVocabulary);
+    $query->condition('field_id', $source->id);
+    $query->condition('langcode', 'fi');
+    $exists = $query->execute();
+
+    if ($source->name->fi === 'maahanmuuttajat') {
+      $name = 'maahan muuttaneet';
+    }
+    else {
+      $name = $source->name->fi;
+    }
+
+    if ($exists) {
+      // Use existing term
+      $term = $this->termStorage->load(current($exists));
+      /** @var \Drupal\taxonomy\Entity\Term $term */
+      $term->set('name', $name);
+      return $term;
+    }
+
+    // Create a new term object.
+    return $this->termStorage->create(
+      [
+        'vid' => $this->termVocabulary,
+        'uid' => $this->userId,
+        'name' => $name,
+        'langcode' => 'fi',
+        'field_id' => $source->id,
+      ]
+    );
+  }
+
+  /**
+   * Add translation to term.
+   *
+   * @param \Drupal\taxonomy\TermInterface $term
+   *   Term to add translation to.
+   * @param \stdClass $source
+   *   Source entity from API.
+   * @param string $langcode
+   *   Langcode to add translation to.
+   *
+   * @return \Drupal\taxonomy\TermInterface
+   */
+  private function addTermTranslation(TermInterface $term, \stdClass $source, string $langcode): TermInterface {
+    if (isset($source->name->$langcode)) {
+      $name = $source->name->$langcode;
+    }
+    else {
+      $name = $source->name->fi;
+    }
+    if ($term->hasTranslation($langcode)) {
+      $translated_term = $term->getTranslation($langcode);
+    }
+    else {
+      $translated_term = $term->addTranslation($langcode);
+    }
+
+    $translated_term->set('name', $name);
+    $translated_term->save();
+    return $translated_term;
   }
 
   /**


### PR DESCRIPTION
This PR adds language support (english and swedish) to the LinkedEvents integration.

**To test**
* Checkout branch
* Run `make drush-cr drush-cim`
* Log in to the container by running `make shell` and then run:
  * `drush edel node --bundle=event`
  * `drush linkedevents:sync -v`
  * `drush sapi-rt;drush sapi-i`
* Check a few events and make sure they have translated data: https://drupal-tyollisyyspalvelut-helfi.docker.so/admin/content?title=&type=event&status=All&langcode=All
  * The event content itself is probably not translated, but the event location should be
  * Check that the content in the new event tags taxonomy term field matches the old tags field
* Check that the event tag terms have been populated and that each tag has translations: https://drupal-tyollisyyspalvelut-helfi.docker.so/admin/structure/taxonomy/manage/event_tags/overview
* Send a POST request to: http://localhost:9200/events_fi/_msearch with the following body. If the request fails, make sure you have the "Content-Type: application/json" header set
```
{"preference":"results"}
{ "query": { "match_all": {} } }

``` 
* Make sure all fields look correct and that the new `field_event_tags` field works
* Send the same response to http://localhost:9200/events_sv/_msearch and http://localhost:9200/events_en/_msearch . You should get translated data from locations and the new field_event_tags field.
* Read the code related to this change.