### PR TITLE
Thf 454 news liftup drupal

### DIFF
--- a/conf/cmi/core.entity_form_display.paragraph.news_list.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.news_list.default.yml
@@ -10,15 +10,26 @@ dependencies:
     - field.field.paragraph.news_list.field_title
     - paragraphs.paragraphs_type.news_list
   module:
+    - select2
     - text
 id: paragraph.news_list.default
 targetEntityType: paragraph
 bundle: news_list
 mode: default
 content:
+  field_background_color:
+    type: select2_entity_reference
+    weight: 1
+    region: content
+    settings:
+      width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
+    third_party_settings: {  }
   field_news_list_desc:
     type: text_textarea
-    weight: 2
+    weight: 4
     region: content
     settings:
       rows: 5
@@ -26,7 +37,7 @@ content:
     third_party_settings: {  }
   field_short_list:
     type: boolean_checkbox
-    weight: 1
+    weight: 3
     region: content
     settings:
       display_label: true
@@ -39,8 +50,12 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  translation:
+    weight: 5
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
-  field_background_color: true
   field_koro: true
   status: true


### PR DESCRIPTION
Added background drop-down selection to the news list paragraph so we can create short news list to the pages with background. When background selection is left blank the background colour is white.

How to test:
This should be tested with PR https://github.com/City-of-Helsinki/employment-services-ui/pull/297
- `make shell`
-  `drush cim -y; drush cr;`
- go edit some landing page example front page.
- you should now see on news list paragraph  background drop-down list.
-  follow the steps to the related PR.
