### PR TITLE
Thf 493 foreign language page templates

### DIFF
--- a/conf/cmi/core.entity_form_display.node.landing_page.default.yml
+++ b/conf/cmi/core.entity_form_display.node.landing_page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.landing_page.field_content
     - field.field.node.landing_page.field_has_hero
     - field.field.node.landing_page.field_hero
+    - field.field.node.landing_page.field_hide_navigation
     - field.field.node.landing_page.field_liftup_image
     - field.field.node.landing_page.field_metatags
     - field.field.node.landing_page.field_notification
@@ -18,6 +19,7 @@ dependencies:
     - paragraphs
     - paragraphs_features
     - path
+    - publication_date
     - scheduler
 third_party_settings:
   field_group:
@@ -46,13 +48,13 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   field_content:
     type: paragraphs
-    weight: 15
+    weight: 17
     region: content
     settings:
       title: Paragraph
@@ -71,14 +73,14 @@ content:
     third_party_settings: {  }
   field_has_hero:
     type: boolean_checkbox
-    weight: 3
+    weight: 4
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_hero:
     type: paragraphs
-    weight: 4
+    weight: 5
     region: content
     settings:
       title: Paragraph
@@ -95,9 +97,16 @@ content:
         collapse_edit_all: '0'
         duplicate: '0'
     third_party_settings: {  }
+  field_hide_navigation:
+    type: boolean_checkbox
+    weight: 1
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 9
+    weight: 10
     region: content
     settings:
       sidebar: false
@@ -105,7 +114,7 @@ content:
     third_party_settings: {  }
   field_notification:
     type: paragraphs
-    weight: 0
+    weight: 5
     region: content
     settings:
       title: Paragraph
@@ -130,7 +139,7 @@ content:
         show_drag_and_drop: false
   field_search_keywords:
     type: entity_reference_autocomplete_tags
-    weight: 5
+    weight: 6
     region: content
     settings:
       match_operator: CONTAINS
@@ -140,70 +149,76 @@ content:
     third_party_settings: {  }
   langcode:
     type: language_select
-    weight: 1
+    weight: 2
     region: content
     settings:
       include_locked: true
     third_party_settings: {  }
   path:
     type: path
-    weight: 13
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
-    type: boolean_checkbox
-    weight: 10
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  publish_on:
-    type: datetime_timestamp_no_default
-    weight: 17
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  scheduler_settings:
-    weight: 16
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  simple_sitemap:
-    weight: 12
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 14
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  sticky:
     type: boolean_checkbox
     weight: 11
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 19
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduler_settings:
+    weight: 18
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 14
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 16
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 13
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 2
+    weight: 3
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 6
+    weight: 7
     region: content
     settings:
       match_operator: CONTAINS
@@ -213,12 +228,12 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 18
+    weight: 20
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 19
+    weight: 21
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_form_display.node.page.default.yml
+++ b/conf/cmi/core.entity_form_display.node.page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.page.field_content
     - field.field.node.page.field_has_hero
     - field.field.node.page.field_hero
+    - field.field.node.page.field_hide_navigation
     - field.field.node.page.field_hide_search
     - field.field.node.page.field_hide_sidebar
     - field.field.node.page.field_lead_in
@@ -22,6 +23,7 @@ dependencies:
     - metatag
     - paragraphs
     - path
+    - publication_date
     - scheduler
 third_party_settings:
   field_group:
@@ -50,13 +52,13 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   field_content:
     type: paragraphs
-    weight: 16
+    weight: 18
     region: content
     settings:
       title: Paragraph
@@ -73,9 +75,16 @@ content:
         collapse_edit_all: collapse_edit_all
         duplicate: duplicate
     third_party_settings: {  }
-  field_hide_search:
+  field_hide_navigation:
     type: boolean_checkbox
     weight: 3
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  field_hide_search:
+    type: boolean_checkbox
+    weight: 4
     region: content
     settings:
       display_label: true
@@ -89,7 +98,7 @@ content:
     third_party_settings: {  }
   field_lead_in:
     type: string_textarea
-    weight: 14
+    weight: 16
     region: content
     settings:
       rows: 3
@@ -97,7 +106,7 @@ content:
     third_party_settings: {  }
   field_lower_content:
     type: paragraphs
-    weight: 22
+    weight: 24
     region: content
     settings:
       title: Paragraph
@@ -116,7 +125,7 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 5
+    weight: 6
     region: content
     settings:
       sidebar: false
@@ -149,7 +158,7 @@ content:
         show_drag_and_drop: false
   field_search_keywords:
     type: entity_reference_autocomplete_tags
-    weight: 15
+    weight: 17
     region: content
     settings:
       match_operator: CONTAINS
@@ -159,7 +168,7 @@ content:
     third_party_settings: {  }
   field_sidebar_content:
     type: paragraphs
-    weight: 17
+    weight: 19
     region: content
     settings:
       title: Paragraph
@@ -185,63 +194,69 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 11
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
-    type: boolean_checkbox
-    weight: 9
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  publish_on:
-    type: datetime_timestamp_no_default
-    weight: 19
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  scheduler_settings:
-    weight: 18
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  simple_sitemap:
-    weight: 12
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 13
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  sticky:
     type: boolean_checkbox
     weight: 10
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 21
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduler_settings:
+    weight: 20
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 14
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 15
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 11
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 4
+    weight: 5
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 6
+    weight: 7
     region: content
     settings:
       match_operator: CONTAINS
@@ -251,12 +266,12 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 20
+    weight: 22
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 21
+    weight: 23
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.node.landing_page.default.yml
+++ b/conf/cmi/core.entity_view_display.node.landing_page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.landing_page.field_content
     - field.field.node.landing_page.field_has_hero
     - field.field.node.landing_page.field_hero
+    - field.field.node.landing_page.field_hide_navigation
     - field.field.node.landing_page.field_liftup_image
     - field.field.node.landing_page.field_metatags
     - field.field.node.landing_page.field_notification
@@ -19,6 +20,16 @@ targetEntityType: node
 bundle: landing_page
 mode: default
 content:
+  field_hide_navigation:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 3
+    region: content
   field_notification:
     type: entity_reference_revisions_entity_view
     label: above

--- a/conf/cmi/core.entity_view_display.node.page.default.yml
+++ b/conf/cmi/core.entity_view_display.node.page.default.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.field.node.page.field_content
     - field.field.node.page.field_has_hero
     - field.field.node.page.field_hero
+    - field.field.node.page.field_hide_navigation
     - field.field.node.page.field_hide_search
     - field.field.node.page.field_hide_sidebar
     - field.field.node.page.field_lead_in
@@ -24,6 +25,16 @@ targetEntityType: node
 bundle: page
 mode: default
 content:
+  field_hide_navigation:
+    type: boolean
+    label: above
+    settings:
+      format: default
+      format_custom_false: ''
+      format_custom_true: ''
+    third_party_settings: {  }
+    weight: 2
+    region: content
   field_notification:
     type: entity_reference_revisions_entity_view
     label: above
@@ -51,5 +62,6 @@ hidden:
   field_search_keywords: true
   field_sidebar_content: true
   langcode: true
+  published_at: true
   search_api_excerpt: true
   toc_enabled: true

--- a/conf/cmi/core.entity_view_display.node.page.search_index.yml
+++ b/conf/cmi/core.entity_view_display.node.page.search_index.yml
@@ -7,6 +7,7 @@ dependencies:
     - field.field.node.page.field_content
     - field.field.node.page.field_has_hero
     - field.field.node.page.field_hero
+    - field.field.node.page.field_hide_navigation
     - field.field.node.page.field_hide_search
     - field.field.node.page.field_hide_sidebar
     - field.field.node.page.field_lead_in
@@ -33,6 +34,7 @@ hidden:
   field_content: true
   field_has_hero: true
   field_hero: true
+  field_hide_navigation: true
   field_hide_search: true
   field_hide_sidebar: true
   field_lead_in: true
@@ -43,5 +45,6 @@ hidden:
   field_search_keywords: true
   field_sidebar_content: true
   langcode: true
+  published_at: true
   search_api_excerpt: true
   toc_enabled: true

--- a/conf/cmi/field.field.node.landing_page.field_hide_navigation.yml
+++ b/conf/cmi/field.field.node.landing_page.field_hide_navigation.yml
@@ -1,0 +1,23 @@
+uuid: 7d77f303-20aa-4a6a-b2dd-d9858e754ea0
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hide_navigation
+    - node.type.landing_page
+id: node.landing_page.field_hide_navigation
+field_name: field_hide_navigation
+entity_type: node
+bundle: landing_page
+label: 'Hide navigation'
+description: ''
+required: false
+translatable: true
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/cmi/field.field.node.page.field_hide_navigation.yml
+++ b/conf/cmi/field.field.node.page.field_hide_navigation.yml
@@ -1,0 +1,23 @@
+uuid: a18d2f01-f2df-4dea-9edb-c794805a96a3
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_hide_navigation
+    - node.type.page
+id: node.page.field_hide_navigation
+field_name: field_hide_navigation
+entity_type: node
+bundle: page
+label: 'Hide navigation'
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: 0
+default_value_callback: ''
+settings:
+  on_label: 'On'
+  off_label: 'Off'
+field_type: boolean

--- a/conf/cmi/field.storage.node.field_hide_navigation.yml
+++ b/conf/cmi/field.storage.node.field_hide_navigation.yml
@@ -1,0 +1,18 @@
+uuid: 602a936e-d7be-45a3-9c88-b0cf69ffc95e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_hide_navigation
+field_name: field_hide_navigation
+entity_type: node
+type: boolean
+settings: {  }
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false


### PR DESCRIPTION
Added possibility to hide nav from basic and landing page. Added boolean filed hide_navigation to page basic and landing. This is not ready for production. Client might need changes to the pages.

How to test:

- test with related branch https://github.com/City-of-Helsinki/employment-services-ui/pull/306
- 'make drush-cim; Make drush cr;'
- Create a landing page and switch the Hide navigation field on.
- You should get the page without nav.
- Create a basic page switch the Hide navigation field on.
- You should get the page without nav.
- The pages should be exactly same as they are in "normal" basic and landing pages.