### PR TITLE
THF-488: Newsletter content functionality for article pages

### DIFF
--- a/conf/cmi/core.entity_form_display.node.article.default.yml
+++ b/conf/cmi/core.entity_form_display.node.article.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.article.field_article_category
     - field.field.node.article.field_author
     - field.field.node.article.field_content
     - field.field.node.article.field_keywords
@@ -17,6 +18,7 @@ dependencies:
     - paragraphs
     - paragraphs_features
     - path
+    - publication_date
     - scheduler
 _core:
   default_config_hash: pCNOhgqtZB0RYWLFELZhHp654GnKfoQ_Dbd2v2MIrWU
@@ -27,13 +29,19 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 6
+    weight: 7
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  field_article_category:
+    type: options_buttons
+    weight: 1
     region: content
     settings: {  }
     third_party_settings: {  }
   field_content:
     type: paragraphs
-    weight: 4
+    weight: 5
     region: content
     settings:
       title: Paragraph
@@ -58,7 +66,7 @@ content:
         show_drag_and_drop: true
   field_lead:
     type: string_textarea
-    weight: 2
+    weight: 3
     region: content
     settings:
       rows: 5
@@ -66,7 +74,7 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 17
+    weight: 19
     region: content
     settings:
       sidebar: false
@@ -74,7 +82,7 @@ content:
     third_party_settings: {  }
   field_search_keywords:
     type: entity_reference_autocomplete_tags
-    weight: 3
+    weight: 4
     region: content
     settings:
       match_operator: CONTAINS
@@ -91,69 +99,69 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 10
+    weight: 11
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
-    type: boolean_checkbox
-    weight: 8
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  publish_on:
-    type: datetime_timestamp_no_default
-    weight: 14
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  published_at:
-    type: publication_date_timestamp
-    weight: 10
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  scheduler_settings:
-    weight: 13
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  simple_sitemap:
-    weight: 12
-    region: content
-    settings: {  }
-    third_party_settings: {  }
-  status:
-    type: boolean_checkbox
-    weight: 11
-    region: content
-    settings:
-      display_label: true
-    third_party_settings: {  }
-  sticky:
     type: boolean_checkbox
     weight: 9
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
+  publish_on:
+    type: datetime_timestamp_no_default
+    weight: 16
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 12
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  scheduler_settings:
+    weight: 15
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  simple_sitemap:
+    weight: 14
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 13
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    weight: 10
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 1
+    weight: 2
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 5
+    weight: 6
     region: content
     settings:
       match_operator: CONTAINS
@@ -163,12 +171,12 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 15
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 16
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_form_display.node.article.default.yml
+++ b/conf/cmi/core.entity_form_display.node.article.default.yml
@@ -108,6 +108,12 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  published_at:
+    type: publication_date_timestamp
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   scheduler_settings:
     weight: 13
     region: content

--- a/conf/cmi/core.entity_form_display.paragraph.news_list.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.news_list.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.paragraph.news_list.field_background_color
     - field.field.paragraph.news_list.field_koro
+    - field.field.paragraph.news_list.field_news_filter
     - field.field.paragraph.news_list.field_news_list_desc
     - field.field.paragraph.news_list.field_short_list
     - field.field.paragraph.news_list.field_title
@@ -27,6 +28,12 @@ content:
       match_operator: CONTAINS
       match_limit: 10
     third_party_settings: {  }
+  field_news_filter:
+    type: options_select
+    weight: 3
+    region: content
+    settings: {  }
+    third_party_settings: {  }
   field_news_list_desc:
     type: text_textarea
     weight: 4
@@ -37,7 +44,7 @@ content:
     third_party_settings: {  }
   field_short_list:
     type: boolean_checkbox
-    weight: 3
+    weight: 2
     region: content
     settings:
       display_label: true
@@ -57,6 +64,5 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
-  field_background_color: true
   field_koro: true
   status: true

--- a/conf/cmi/core.entity_view_display.node.article.default.yml
+++ b/conf/cmi/core.entity_view_display.node.article.default.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.field.node.article.field_article_category
     - field.field.node.article.field_author
     - field.field.node.article.field_content
     - field.field.node.article.field_keywords
@@ -24,6 +25,7 @@ content:
     weight: 0
     region: content
 hidden:
+  field_article_category: true
   field_author: true
   field_content: true
   field_keywords: true
@@ -32,5 +34,6 @@ hidden:
   field_metatags: true
   field_search_keywords: true
   langcode: true
+  published_at: true
   search_api_excerpt: true
   toc_enabled: true

--- a/conf/cmi/core.entity_view_display.paragraph.news_list.default.yml
+++ b/conf/cmi/core.entity_view_display.paragraph.news_list.default.yml
@@ -5,17 +5,26 @@ dependencies:
   config:
     - field.field.paragraph.news_list.field_background_color
     - field.field.paragraph.news_list.field_koro
+    - field.field.paragraph.news_list.field_news_filter
     - field.field.paragraph.news_list.field_news_list_desc
     - field.field.paragraph.news_list.field_short_list
     - field.field.paragraph.news_list.field_title
     - paragraphs.paragraphs_type.news_list
   module:
+    - options
     - text
 id: paragraph.news_list.default
 targetEntityType: paragraph
 bundle: news_list
 mode: default
 content:
+  field_news_filter:
+    type: list_default
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
+    region: content
   field_news_list_desc:
     type: text_default
     label: above

--- a/conf/cmi/field.field.node.article.field_article_category.yml
+++ b/conf/cmi/field.field.node.article.field_article_category.yml
@@ -1,0 +1,23 @@
+uuid: 44148405-33af-40ac-adee-24fffd94c919
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_article_category
+    - node.type.article
+  module:
+    - options
+id: node.article.field_article_category
+field_name: field_article_category
+entity_type: node
+bundle: article
+label: 'Article category'
+description: ''
+required: true
+translatable: false
+default_value:
+  -
+    value: news
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/conf/cmi/field.field.node.article.field_content.yml
+++ b/conf/cmi/field.field.node.article.field_content.yml
@@ -5,14 +5,19 @@ dependencies:
   config:
     - field.storage.node.field_content
     - node.type.article
+    - paragraphs.paragraphs_type.accordion
+    - paragraphs.paragraphs_type.banner
     - paragraphs.paragraphs_type.columns
     - paragraphs.paragraphs_type.content_cards
+    - paragraphs.paragraphs_type.events_list
     - paragraphs.paragraphs_type.from_library
     - paragraphs.paragraphs_type.gallery
     - paragraphs.paragraphs_type.image
+    - paragraphs.paragraphs_type.liftup_with_image
     - paragraphs.paragraphs_type.list_of_links
     - paragraphs.paragraphs_type.quote
     - paragraphs.paragraphs_type.remote_video
+    - paragraphs.paragraphs_type.subheading
     - paragraphs.paragraphs_type.text
     - paragraphs.paragraphs_type.unit_search
   module:
@@ -39,21 +44,26 @@ settings:
       gallery: gallery
       list_of_links: list_of_links
       content_cards: content_cards
+      accordion: accordion
+      banner: banner
+      liftup_with_image: liftup_with_image
       from_library: from_library
       remote_video: remote_video
       unit_search: unit_search
+      events_list: events_list
       quote: quote
+      subheading: subheading
     negate: 0
     target_bundles_drag_drop:
       accordion:
         weight: -21
-        enabled: false
+        enabled: true
       accordion_item:
         weight: -20
         enabled: false
       banner:
         weight: -16
-        enabled: false
+        enabled: true
       blog_list:
         weight: 40
         enabled: false
@@ -77,7 +87,7 @@ settings:
         enabled: false
       events_list:
         weight: 47
-        enabled: false
+        enabled: true
       from_library:
         weight: 21
         enabled: true
@@ -101,7 +111,7 @@ settings:
         enabled: false
       liftup_with_image:
         weight: -15
-        enabled: false
+        enabled: true
       link:
         weight: 56
         enabled: false
@@ -140,16 +150,22 @@ settings:
         enabled: false
       subheading:
         weight: 68
-        enabled: false
+        enabled: true
       sujo_embedded:
         weight: 69
         enabled: false
       text:
         weight: -27
         enabled: true
+      unit_map:
+        weight: 73
+        enabled: false
       unit_search:
         weight: 28
         enabled: true
+      units_list:
+        weight: 75
+        enabled: false
       video:
         weight: 72
         enabled: false

--- a/conf/cmi/field.field.paragraph.news_list.field_news_filter.yml
+++ b/conf/cmi/field.field.paragraph.news_list.field_news_filter.yml
@@ -1,0 +1,23 @@
+uuid: 9082c2a0-9334-4cdd-b452-f6e4920f3c9d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.paragraph.field_news_filter
+    - paragraphs.paragraphs_type.news_list
+  module:
+    - options
+id: paragraph.news_list.field_news_filter
+field_name: field_news_filter
+entity_type: paragraph
+bundle: news_list
+label: Filter
+description: ''
+required: false
+translatable: false
+default_value:
+  -
+    value: news
+default_value_callback: ''
+settings: {  }
+field_type: list_string

--- a/conf/cmi/field.storage.node.field_article_category.yml
+++ b/conf/cmi/field.storage.node.field_article_category.yml
@@ -1,0 +1,27 @@
+uuid: 08f197e9-0309-41c1-9768-2ef4798666b4
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - options
+id: node.field_article_category
+field_name: field_article_category
+entity_type: node
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: news
+      label: News
+    -
+      value: newsletter
+      label: Newsletter
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.paragraph.field_news_filter.yml
+++ b/conf/cmi/field.storage.paragraph.field_news_filter.yml
@@ -1,0 +1,30 @@
+uuid: 2640e401-feb0-4749-b9bf-908445fd1d6f
+langcode: en
+status: true
+dependencies:
+  module:
+    - options
+    - paragraphs
+id: paragraph.field_news_filter
+field_name: field_news_filter
+entity_type: paragraph
+type: list_string
+settings:
+  allowed_values:
+    -
+      value: news
+      label: News
+    -
+      value: newsletter
+      label: Newsletters
+    -
+      value: all
+      label: 'All articles'
+  allowed_values_function: ''
+module: options
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language/fi/field.field.node.article.field_article_category.yml
+++ b/conf/cmi/language/fi/field.field.node.article.field_article_category.yml
@@ -1,0 +1,1 @@
+label: 'Artikkelin kategoria'

--- a/conf/cmi/language/fi/field.storage.node.field_article_category.yml
+++ b/conf/cmi/language/fi/field.storage.node.field_article_category.yml
@@ -1,0 +1,6 @@
+settings:
+  allowed_values:
+    -
+      label: Uutinen
+    -
+      label: Uutiskirje

--- a/conf/cmi/search_api.index.articles_en.yml
+++ b/conf/cmi/search_api.index.articles_en.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.field_article_category
     - field.storage.node.field_content
     - field.storage.paragraph.field_accordion_text
     - field.storage.paragraph.field_text
@@ -54,6 +55,14 @@ field_settings:
         - field.storage.paragraph.field_accordion_title
       module:
         - paragraphs
+  field_article_category:
+    label: 'Article category'
+    datasource_id: 'entity:node'
+    property_path: field_article_category
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_article_category
   field_lead_in:
     label: Lead
     datasource_id: 'entity:node'
@@ -131,6 +140,7 @@ processor_settings:
       - entity_type
       - field_accordion_text
       - field_accordion_title
+      - field_article_category
       - field_lead_in
       - field_search_keywords
       - field_text

--- a/conf/cmi/search_api.index.articles_fi.yml
+++ b/conf/cmi/search_api.index.articles_fi.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.field_article_category
     - field.storage.node.field_content
     - field.storage.paragraph.field_accordion_text
     - field.storage.paragraph.field_text
@@ -54,6 +55,14 @@ field_settings:
         - field.storage.paragraph.field_accordion_title
       module:
         - paragraphs
+  field_article_category:
+    label: 'Article category'
+    datasource_id: 'entity:node'
+    property_path: field_article_category
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_article_category
   field_lead_in:
     label: Lead
     datasource_id: 'entity:node'
@@ -131,6 +140,7 @@ processor_settings:
       - entity_type
       - field_accordion_text
       - field_accordion_title
+      - field_article_category
       - field_lead_in
       - field_search_keywords
       - field_text

--- a/conf/cmi/search_api.index.articles_sv.yml
+++ b/conf/cmi/search_api.index.articles_sv.yml
@@ -3,6 +3,7 @@ langcode: en
 status: true
 dependencies:
   config:
+    - field.storage.node.field_article_category
     - field.storage.node.field_content
     - field.storage.paragraph.field_accordion_text
     - field.storage.paragraph.field_text
@@ -54,6 +55,14 @@ field_settings:
         - field.storage.paragraph.field_accordion_title
       module:
         - paragraphs
+  field_article_category:
+    label: 'Article category'
+    datasource_id: 'entity:node'
+    property_path: field_article_category
+    type: string
+    dependencies:
+      config:
+        - field.storage.node.field_article_category
   field_lead_in:
     label: Lead
     datasource_id: 'entity:node'
@@ -131,6 +140,7 @@ processor_settings:
       - entity_type
       - field_accordion_text
       - field_accordion_title
+      - field_article_category
       - field_lead_in
       - field_search_keywords
       - field_text

--- a/public/modules/custom/tyollisyyspalvelut_common/tyollisyyspalvelut_common.module
+++ b/public/modules/custom/tyollisyyspalvelut_common/tyollisyyspalvelut_common.module
@@ -93,5 +93,20 @@ function tyollisyyspalvelut_common_pathauto_pattern_alter(\Drupal\pathauto\Patha
       // Use Node title as last pattern for no-menu cases.
       $pattern->setPattern('[node:menu-link:parents:join-path]/[node:title]');
     }
+
+    // Swap news patterns to newsletter patterns.
+    $news_patterns = [
+      'ajankohtaista/uutiset/[node:title]' => 'ajankohtaista/uutiskirjeet/[node:title]',
+      'aktuellt/nyheter/[node:title]' => 'aktuellt/nyhetsbrev/[node:title]',
+      'current-matters/news/[node:title]' => 'current-matters/newsletters/[node:title]',
+    ];
+
+    if (in_array($pattern->getPattern(), array_keys($news_patterns))) {
+      if ($node->hasField('field_article_category')
+        && !$node->get('field_article_category')->isEmpty()
+        && $node->get('field_article_category')->value === 'newsletter') {
+        $pattern->setPattern($news_patterns[$pattern->getPattern()]);
+      }
+    }
   }
 }


### PR DESCRIPTION
This PR:
- Adds missing paragraph components to articles
- Adds an article category field to differentiate between news and newsletters
- Customizes URL aliases for newsletter articles

**To test**
- Checkout branch, run `make drush-cim drush-cr`
- Also checkout and install this UI branch: https://github.com/City-of-Helsinki/employment-services-ui/pull/322
- Edit all article nodes and select the "news" article type: https://drupal-tyollisyyspalvelut-helfi.docker.so/admin/content
  - When you edit the articles, the URL alias should stay the same (`/ajankohtaista/uutiset/article-title*`) 
- Create a few new articles and select the "newsletter" article type: https://drupal-tyollisyyspalvelut-helfi.docker.so/node/add/article
  - This time the URL should be something like `ajankohtaista/uutiskirjeet/article-title`
- Edit the news page and change the news list component's filter to "News": https://drupal-tyollisyyspalvelut-helfi.docker.so/ajankohtaista/uutiset
  - The list should only have news articles and no newsletters 
- Create a new landing page "Uutiskirjeet" (make sure the URL alias is `ajankohtaista/uutistkirjeet`, add a news list component and select "Newsletters"
  - The list should only have newsletters, now news articles 
- Edit the frontpage news list component and test all values for the filter. You should be able to list only news, only newsletters or both