### PR TITLE
THF-523: THF-523: Add menu for other languages

### DIFF
--- a/conf/cmi/system.menu.menu-other-languages.yml
+++ b/conf/cmi/system.menu.menu-other-languages.yml
@@ -1,0 +1,8 @@
+uuid: 921bde4f-37e9-4b0d-a0aa-8f85adbe9b6a
+langcode: zxx
+status: true
+dependencies: {  }
+id: menu-other-languages
+label: 'Menu (other languages)'
+description: ''
+locked: false


### PR DESCRIPTION
Add menu for other languages.

how to test:

- `make drush-cim drush-cr`
- We should now have menu `Menu (other languages)` on page https://drupal-tyollisyyspalvelut-helfi.docker.so/admin/structure/menu