### PR TITLE
THF-572: THF-572: Change Cron run every hour

### DIFF
--- a/conf/cmi/automated_cron.settings.yml
+++ b/conf/cmi/automated_cron.settings.yml
@@ -1,4 +1,4 @@
 _core:
   default_config_hash: fUksROt4FfkAU9BV4hV2XvhTBSS2nTNrZS4U7S-tKrs
 langcode: fi
-interval: 3600
+interval: 0

--- a/conf/cmi/automated_cron.settings.yml
+++ b/conf/cmi/automated_cron.settings.yml
@@ -1,4 +1,4 @@
 _core:
   default_config_hash: fUksROt4FfkAU9BV4hV2XvhTBSS2nTNrZS4U7S-tKrs
 langcode: fi
-interval: 10800
+interval: 3600

--- a/conf/cmi/core.entity_form_display.node.article.default.yml
+++ b/conf/cmi/core.entity_form_display.node.article.default.yml
@@ -185,4 +185,3 @@ hidden:
   field_keywords: true
   field_liftup_image: true
   hide_sidebar_navigation: true
- 

--- a/conf/cmi/system.date.yml
+++ b/conf/cmi/system.date.yml
@@ -7,6 +7,6 @@ country:
 timezone:
   default: Europe/Helsinki
   user:
-    configurable: true
+    configurable: false
     default: 0
     warn: false

--- a/conf/cmi/user.role.authenticated.yml
+++ b/conf/cmi/user.role.authenticated.yml
@@ -30,6 +30,7 @@ dependencies:
     - paragraphs_type_permissions
     - path
     - pathauto
+    - publication_date
     - quick_node_clone
     - search
     - shortcut
@@ -225,6 +226,7 @@ permissions:
   - 'revert landing_page revisions'
   - 'revert page revisions'
   - 'search content'
+  - 'set article published on date'
   - 'skip comment approval'
   - 'translate any entity'
   - 'translate article node'


### PR DESCRIPTION
Enabled scheduler and change cron run to run every hour. (before every 3 hours). Also users can not change timezone anymore from the user section. 

How to test
- Test this branch with branch https://github.com/City-of-Helsinki/employment-services-ui/compare/develop...THF-572-scheduler-ui?expand=1
- `drush cim -y; drush cr;`
- Create an article and publish it. You should have published article
- Create again a new article and schedule the publishing 2 min later.
- Wait about 3 min and run cron run https://drupal-tyollisyyspalvelut-helfi.docker.so/admin/config/system/cron
- The article should be now published. 
- Check also that the cron run is updated to run every hour.
- Go to https://drupal-tyollisyyspalvelut-helfi.docker.so/admin/people
- Go edit some user. You shouldn't have option to change the timezone.