### PR TITLE
THF-562: THF-562: Add partner_job filer

### DIFF
--- a/conf/cmi/core.entity_form_display.node.article.default.yml
+++ b/conf/cmi/core.entity_form_display.node.article.default.yml
@@ -185,4 +185,3 @@ hidden:
   field_keywords: true
   field_liftup_image: true
   hide_sidebar_navigation: true
- 

--- a/conf/cmi/core.entity_form_display.paragraph.liftup_with_image.default.yml
+++ b/conf/cmi/core.entity_form_display.paragraph.liftup_with_image.default.yml
@@ -48,6 +48,11 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
 hidden:
   created: true
   status: true

--- a/conf/cmi/core.entity_view_display.paragraph.liftup_with_image.default.yml
+++ b/conf/cmi/core.entity_view_display.paragraph.liftup_with_image.default.yml
@@ -49,4 +49,5 @@ content:
     third_party_settings: {  }
     weight: 0
     region: content
-hidden: {  }
+hidden:
+  search_api_excerpt: true

--- a/conf/cmi/field.field.node.page.field_content.yml
+++ b/conf/cmi/field.field.node.page.field_content.yml
@@ -11,6 +11,7 @@ dependencies:
     - paragraphs.paragraphs_type.image
     - paragraphs.paragraphs_type.liftup_with_image
     - paragraphs.paragraphs_type.list_of_links
+    - paragraphs.paragraphs_type.news_list
     - paragraphs.paragraphs_type.notification
     - paragraphs.paragraphs_type.subheading
     - paragraphs.paragraphs_type.text
@@ -40,6 +41,7 @@ settings:
       liftup_with_image: liftup_with_image
       events_list: events_list
       notification: notification
+      news_list: news_list
       subheading: subheading
     negate: 0
     target_bundles_drag_drop:
@@ -114,7 +116,7 @@ settings:
         enabled: false
       news_list:
         weight: 62
-        enabled: false
+        enabled: true
       notification:
         weight: 60
         enabled: true
@@ -145,8 +147,14 @@ settings:
       text:
         weight: -27
         enabled: true
+      unit_map:
+        weight: 73
+        enabled: false
       unit_search:
         weight: 28
+        enabled: false
+      units_list:
+        weight: 75
         enabled: false
       video:
         weight: 72

--- a/conf/cmi/field.storage.node.field_article_category.yml
+++ b/conf/cmi/field.storage.node.field_article_category.yml
@@ -17,6 +17,9 @@ settings:
     -
       value: newsletter
       label: Newsletter
+    -
+      value: partner_jobs
+      label: 'Jobs offered by partners'
   allowed_values_function: ''
 module: options
 locked: false

--- a/conf/cmi/field.storage.paragraph.field_news_filter.yml
+++ b/conf/cmi/field.storage.paragraph.field_news_filter.yml
@@ -18,6 +18,9 @@ settings:
       value: newsletter
       label: Newsletters
     -
+      value: partner_jobs
+      label: 'Jobs offered by partners'
+    -
       value: all
       label: 'All articles'
   allowed_values_function: ''


### PR DESCRIPTION
Added new filter to paragrah News List, new category to article category and News list paragraph to Basic page.

how to test
- test with UI branch https://github.com/City-of-Helsinki/employment-services-ui/pull/343
- `make shell;`
- `drush cim -y; drush cr;`
-  Create few articles with Article category "Jobs offered by partners"
- Add News list to https://drupal-tyollisyyspalvelut-helfi.docker.so/tyonhaku/tuetut-tyopaikat/palkkatuki/kumppanien-tarjoamat-tyopaikat
- You should now see list of news that you just created (max 4) on partner job page.
- Test also that if you change the filter fo the news list you get correct news on the list.  