### PR TITLE
THF-501: THF-501: Add preindexing for roudikko filtering

### DIFF
--- a/public/modules/custom/tyollisyyspalvelut_elasticsearch/src/EventSubscriber/PrepareIndexSubscriber.php
+++ b/public/modules/custom/tyollisyyspalvelut_elasticsearch/src/EventSubscriber/PrepareIndexSubscriber.php
@@ -67,32 +67,56 @@ class PrepareIndexSubscriber implements EventSubscriberInterface {
     $filter_name = $stemmer_language . '_stop';
     $filter_language = '_' . $stemmer_language . '_';
 
-    $indexConfig["body"]["settings"]["index"] = [
-      "analysis" => [
-        "analyzer" => [
-          "default" => [
-            "type" => "custom",
-            "filter" => [
-              "lowercase",
-              "stop",
-              "filter_stemmer",
-              $filter_name,
+    if ($langcode === 'fi') {
+      $indexConfig["body"]["settings"]["index"] = [
+        "analysis" => [
+          "analyzer" => [
+            "default" => [
+              "type" => "custom",
+              "filter" => [
+                "lowercase",
+                "raudikkoFilter",
+              ],
+              "tokenizer" => "finnish",
             ],
-            "tokenizer" => "standard",
+          ],
+          "filter" => [
+            "raudikkoFilter" => [
+              "type" => "raudikko",
+            ],
           ],
         ],
-        "filter" => [
-          "filter_stemmer" => [
-            "type" => "stemmer",
-            "language" => $stemmer_language,
+      ];
+    }
+    else {
+      $indexConfig["body"]["settings"]["index"] = [
+        "analysis" => [
+          "analyzer" => [
+            "default" => [
+              "type" => "custom",
+              "filter" => [
+                "lowercase",
+                "stop",
+                "filter_stemmer",
+                $filter_name,
+              ],
+              "tokenizer" => "standard",
+            ],
           ],
-          $filter_name => [
-            "type" => "stop",
-            "stopwords" => $filter_language,
+          "filter" => [
+            "filter_stemmer" => [
+              "type" => "stemmer",
+              "language" => $stemmer_language,
+            ],
+            $filter_name => [
+              "type" => "stop",
+              "stopwords" => $filter_language,
+            ],
           ],
         ],
-      ],
-    ];
+      ];
+    }
+
 
     $event->setIndexConfig($indexConfig);
   }


### PR DESCRIPTION
Changed search to use Raudikko pluggin when language is Finnish.

Setting the project

- Setup Dockerfile and edit docker-compose.yml 

- Start Stonehead, Drupal and next Project

- In Drupal root directory run 
`curl -X DELETE http://localhost:9200/\*_fi`
`curl -X DELETE http://localhost:9200/\*_en`
`curl -X DELETE http://localhost:9200/\*_sv`
after a successful run you'll get response {"acknowledged":true}%

- `make shell`
- `drush search-api:clear`
- `drush sapi-rt`
- `drush sapi-i`

- after a successful run check http://localhost:9200/*_en , http://localhost:9200/*_sv and http://localhost:9200/*_en
- en and sv pages should have filter_stammer 
```
"filter": {
"filter_stemmer": {
"type": "stemmer",
"language": "english"
},
"english_stop": {
"type": "stop",
"stopwords": "_english_"
}
- fi should have 
```
```
- {
      "filter": {
        "raudikkoFilter": {
          "type": "raudikko"
        }
      }
    }
  }
}
```
After you have checked all setting try the search with all languages. 