### PR TITLE
THF-533: THF-533: Add in_language handling

### DIFF
--- a/conf/cmi/core.entity_form_display.node.event.default.yml
+++ b/conf/cmi/core.entity_form_display.node.event.default.yml
@@ -47,7 +47,7 @@ content:
     third_party_settings: {  }
   field_end_time:
     type: string_textfield
-    weight: 20
+    weight: 19
     region: content
     settings:
       size: 60
@@ -55,7 +55,7 @@ content:
     third_party_settings: {  }
   field_event_status:
     type: string_textfield
-    weight: 18
+    weight: 17
     region: content
     settings:
       size: 60
@@ -111,6 +111,16 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_in_language:
+    type: select2_entity_reference
+    weight: 26
+    region: content
+    settings:
+      width: 100%
+      autocomplete: false
+      match_operator: CONTAINS
+      match_limit: 10
+    third_party_settings: {  }
   field_info_url:
     type: string_textfield
     weight: 29
@@ -121,7 +131,7 @@ content:
     third_party_settings: {  }
   field_last_modified_time:
     type: string_textfield
-    weight: 21
+    weight: 20
     region: content
     settings:
       size: 60
@@ -129,7 +139,7 @@ content:
     third_party_settings: {  }
   field_location:
     type: string_textfield
-    weight: 22
+    weight: 21
     region: content
     settings:
       size: 60
@@ -137,7 +147,7 @@ content:
     third_party_settings: {  }
   field_location_extra_info:
     type: string_textfield
-    weight: 25
+    weight: 24
     region: content
     settings:
       size: 60
@@ -145,7 +155,7 @@ content:
     third_party_settings: {  }
   field_location_id:
     type: number
-    weight: 24
+    weight: 23
     region: content
     settings:
       placeholder: ''
@@ -168,7 +178,7 @@ content:
     third_party_settings: {  }
   field_publisher:
     type: string_textfield
-    weight: 26
+    weight: 25
     region: content
     settings:
       size: 60
@@ -184,7 +194,7 @@ content:
     third_party_settings: {  }
   field_start_time:
     type: string_textfield
-    weight: 19
+    weight: 18
     region: content
     settings:
       size: 60
@@ -192,7 +202,7 @@ content:
     third_party_settings: {  }
   field_street_address:
     type: string_textfield
-    weight: 23
+    weight: 22
     region: content
     settings:
       size: 60

--- a/conf/cmi/core.entity_form_display.taxonomy_term.event_languages.default.yml
+++ b/conf/cmi/core.entity_form_display.taxonomy_term.event_languages.default.yml
@@ -1,0 +1,65 @@
+uuid: 4cd53986-9067-47d5-8ef9-64fedc899a9c
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.event_languages.field_language_id
+    - taxonomy.vocabulary.event_languages
+  module:
+    - path
+    - text
+id: taxonomy_term.event_languages.default
+targetEntityType: taxonomy_term
+bundle: event_languages
+mode: default
+content:
+  description:
+    type: text_textfield
+    weight: 0
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_language_id:
+    type: string_textfield
+    weight: 101
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  langcode:
+    type: language_select
+    weight: 2
+    region: content
+    settings:
+      include_locked: true
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -5
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  path:
+    type: path
+    weight: 30
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+  status:
+    type: boolean_checkbox
+    weight: 100
+    region: content
+    settings:
+      display_label: true
+    third_party_settings: {  }
+  translation:
+    weight: 10
+    region: content
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/conf/cmi/core.entity_view_display.taxonomy_term.event_languages.default.yml
+++ b/conf/cmi/core.entity_view_display.taxonomy_term.event_languages.default.yml
@@ -1,0 +1,32 @@
+uuid: 025578f1-fb52-4e15-a85e-e272180f5b51
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.taxonomy_term.event_languages.field_language_id
+    - taxonomy.vocabulary.event_languages
+  module:
+    - text
+id: taxonomy_term.event_languages.default
+targetEntityType: taxonomy_term
+bundle: event_languages
+mode: default
+content:
+  description:
+    type: text_default
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+    weight: 0
+    region: content
+  field_language_id:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 1
+    region: content
+hidden:
+  langcode: true
+  search_api_excerpt: true

--- a/conf/cmi/field.field.node.event.field_in_language.yml
+++ b/conf/cmi/field.field.node.event.field_in_language.yml
@@ -1,19 +1,29 @@
-uuid: 66526392-fdd1-4a17-b393-0925200d7b0b
+uuid: 7f881f61-a328-4bac-92e5-e57db99cb2fd
 langcode: en
 status: true
 dependencies:
   config:
     - field.storage.node.field_in_language
     - node.type.event
+    - taxonomy.vocabulary.event_languages
 id: node.event.field_in_language
 field_name: field_in_language
 entity_type: node
 bundle: event
-label: 'in language'
+label: 'In Language'
 description: ''
 required: false
-translatable: true
+translatable: false
 default_value: {  }
 default_value_callback: ''
-settings: {  }
-field_type: string
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      event_languages: event_languages
+    sort:
+      field: name
+      direction: asc
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/conf/cmi/field.field.taxonomy_term.event_languages.field_language_id.yml
+++ b/conf/cmi/field.field.taxonomy_term.event_languages.field_language_id.yml
@@ -1,0 +1,19 @@
+uuid: 0be3eefa-fffa-44b5-adeb-4df256a682f9
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.taxonomy_term.field_language_id
+    - taxonomy.vocabulary.event_languages
+id: taxonomy_term.event_languages.field_language_id
+field_name: field_language_id
+entity_type: taxonomy_term
+bundle: event_languages
+label: 'Language ID'
+description: ''
+required: true
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.node.field_in_language.yml
+++ b/conf/cmi/field.storage.node.field_in_language.yml
@@ -1,20 +1,19 @@
-uuid: 7fd6cc7c-8d6b-483e-a011-f9c5e89dda53
+uuid: 059ae4ec-c965-4a9e-8743-bd7f68b90cdc
 langcode: en
 status: true
 dependencies:
   module:
     - node
+    - taxonomy
 id: node.field_in_language
 field_name: field_in_language
 entity_type: node
-type: string
+type: entity_reference
 settings:
-  max_length: 255
-  case_sensitive: false
-  is_ascii: false
+  target_type: taxonomy_term
 module: core
 locked: false
-cardinality: 1
+cardinality: -1
 translatable: true
 indexes: {  }
 persist_with_no_fields: false

--- a/conf/cmi/field.storage.taxonomy_term.field_language_id.yml
+++ b/conf/cmi/field.storage.taxonomy_term.field_language_id.yml
@@ -1,0 +1,21 @@
+uuid: 99569b86-e2ab-4e5b-8c65-97f1831a7ab6
+langcode: en
+status: true
+dependencies:
+  module:
+    - taxonomy
+id: taxonomy_term.field_language_id
+field_name: field_language_id
+entity_type: taxonomy_term
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/language.content_settings.taxonomy_term.event_languages.yml
+++ b/conf/cmi/language.content_settings.taxonomy_term.event_languages.yml
@@ -1,0 +1,16 @@
+uuid: 4b6cc087-6fde-4cbc-9834-1da75555c90d
+langcode: en
+status: true
+dependencies:
+  config:
+    - taxonomy.vocabulary.event_languages
+  module:
+    - content_translation
+third_party_settings:
+  content_translation:
+    enabled: true
+id: taxonomy_term.event_languages
+target_entity_type_id: taxonomy_term
+target_bundle: event_languages
+default_langcode: site_default
+language_alterable: false

--- a/conf/cmi/taxonomy.vocabulary.event_languages.yml
+++ b/conf/cmi/taxonomy.vocabulary.event_languages.yml
@@ -1,0 +1,8 @@
+uuid: dbefcf47-ff9a-4389-9d62-837e90844835
+langcode: en
+status: true
+dependencies: {  }
+name: 'Event Languages'
+vid: event_languages
+description: ''
+weight: 0

--- a/public/modules/custom/tyollisyyspalvelut_elasticsearch/src/EventSubscriber/PrepareIndexMappingSubscriber.php
+++ b/public/modules/custom/tyollisyyspalvelut_elasticsearch/src/EventSubscriber/PrepareIndexMappingSubscriber.php
@@ -37,7 +37,7 @@ class PrepareIndexMappingSubscriber implements EventSubscriberInterface {
       $indexKey = $mappingParams['type'];
       foreach ($mappingParams['body'][$indexKey]['properties'] as $key => $property) {
         if ($property['type'] == 'text') {
-          $mappingParams['body'][$indexKey]['properties'][$key]['analyzer'] = $mappingParams['body'][$indexKey]['properties'][$key]['analyzer'] ?? 'standard';
+          $mappingParams['body'][$indexKey]['properties'][$key]['analyzer'] = $mappingParams['body'][$indexKey]['properties'][$key]['analyzer'] ?? 'index_analyzer';
         }
       }
     }

--- a/public/modules/custom/tyollisyyspalvelut_elasticsearch/src/EventSubscriber/PrepareIndexMappingSubscriber.php
+++ b/public/modules/custom/tyollisyyspalvelut_elasticsearch/src/EventSubscriber/PrepareIndexMappingSubscriber.php
@@ -37,7 +37,7 @@ class PrepareIndexMappingSubscriber implements EventSubscriberInterface {
       $indexKey = $mappingParams['type'];
       foreach ($mappingParams['body'][$indexKey]['properties'] as $key => $property) {
         if ($property['type'] == 'text') {
-          $mappingParams['body'][$indexKey]['properties'][$key]['analyzer'] = $mappingParams['body'][$indexKey]['properties'][$key]['analyzer'] ?? 'index_analyzer';
+          $mappingParams['body'][$indexKey]['properties'][$key]['analyzer'] = $mappingParams['body'][$indexKey]['properties'][$key]['analyzer'] ?? 'standard';
         }
       }
     }

--- a/public/modules/custom/tyollisyyspalvelut_elasticsearch/src/EventSubscriber/PrepareIndexSubscriber.php
+++ b/public/modules/custom/tyollisyyspalvelut_elasticsearch/src/EventSubscriber/PrepareIndexSubscriber.php
@@ -7,7 +7,6 @@ use Drupal\Core\Language\LanguageManager;
 use Drupal\elasticsearch_connector\ElasticSearch\Parameters\Factory\IndexFactory;
 use Drupal\elasticsearch_connector\Event\PrepareIndexEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Drupal\Component\EventDispatcher\Event;
 use Drupal\search_api\IndexInterface;
 
 /**

--- a/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
+++ b/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
@@ -303,6 +303,8 @@ class SyncContent extends DrushCommands {
       // Add keywords as taxonomy terms, along with translations.
       $node = $this->nodeAddTaxonomyTerms($node, $item);
 
+      $node = $this->nodeAddLanguageTaxonomyTerms($node, $item);
+
       // Update process log.
       $node->isNew() ? $this->processLog['new']++ : $this->processLog['updated']++;
       // Save the node.
@@ -420,17 +422,8 @@ class SyncContent extends DrushCommands {
     $tids = [];
     foreach ($source->in_language as $lang) {
       $data = $this->fetch($lang->{'@id'});
-
       $term = $this->termInit($data, $this->termLanguageVocabulary, 'field_language_id');
       $term->save();
-
-      foreach ($this->languages as $langcode) {
-        if ($langcode === 'fi') {
-          continue;
-        }
-        $this->addTermTranslation($term, $data, $langcode);
-      }
-
       $tids[] = $term->id();
     }
 
@@ -493,7 +486,6 @@ class SyncContent extends DrushCommands {
     $node->field_info_url = isset($source->info_url->$langcode) && strlen($source->info_url->$langcode) <= 255 ? $source->info_url->$langcode : '';
     $node->field_location_extra_info = $source->location_extra_info->$langcode ?? $source->location_extra_info->fi ?? '';
     $node->field_street_address = $source->location->street_address->$langcode ?? $source->location->street_address->fi ?? '';
-    $node->field_in_language = $this->getLanguages($source, $langcode);
     $node->field_provider = $source->provider->$langcode ?? $source->provider->fi ?? '';
 
     // Hardcode tags to finnish for now.

--- a/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
+++ b/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
@@ -212,8 +212,7 @@ class SyncContent extends DrushCommands {
       // Read next chunk of data, or get NULL to stop the loop
       $data = $this->fetch($data->meta->next);
     }
-
-    // Remove expired nodes
+    
     $this->output()->writeln('Removing expired..');
     $this->removeExpiredNodes();
 

--- a/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
+++ b/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
@@ -480,6 +480,18 @@ class SyncContent extends DrushCommands {
     return $node;
   }
 
+  /**
+   * Language object initializer.
+   *
+   * @param \stdClass $source
+   *   Entity data from API.
+   *
+   * @param string $langcode
+   *   Language code for translation.
+   *
+   * @return string
+   *   Returns string with languages available for the event.
+   */
   private function getLanguages(\stdClass $source, string $langcode): string {
     $in_language = '';
     foreach ($source->in_language as $lang) {

--- a/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
+++ b/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
@@ -205,6 +205,9 @@ class SyncContent extends DrushCommands {
       $data = $this->fetch($data->meta->next);
     }
 
+    // Output info
+    $this->output()->writeln('Removing expired..');
+
     // Remove expired nodes
     $this->output()->writeln('Removing expired..');
     $this->removeExpiredNodes();
@@ -449,6 +452,7 @@ class SyncContent extends DrushCommands {
     $node->field_info_url = isset($source->info_url->$langcode) && strlen($source->info_url->$langcode) <= 255 ? $source->info_url->$langcode : '';
     $node->field_location_extra_info = $source->location_extra_info->$langcode ?? $source->location_extra_info->fi ?? '';
     $node->field_street_address = $source->location->street_address->$langcode ?? $source->location->street_address->fi ?? '';
+    $node->field_in_language = $this->getLanguages($source, $langcode);
     $node->field_provider = $source->provider->$langcode ?? $source->provider->fi ?? '';
 
     // Hardcode tags to finnish for now.
@@ -474,6 +478,20 @@ class SyncContent extends DrushCommands {
     }
 
     return $node;
+  }
+
+  private function getLanguages(\stdClass $source, string $langcode): string {
+    $in_language = '';
+    foreach ($source->in_language as $lang) {
+      $data = $this->fetch($lang->{'@id'});
+      if ($lang === end($source->in_language)) {
+        $in_language .=  ucfirst($data->name->$langcode ?? $data->name->fi ?? '');
+      }
+      else {
+        $in_language .= ucfirst($data->name->$langcode ?? $data->name->fi ?? '') . ', ';
+      }
+    }
+    return $in_language;
   }
 
   /**

--- a/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
+++ b/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
@@ -213,7 +213,7 @@ class SyncContent extends DrushCommands {
       $data = $this->fetch($data->meta->next);
     }
 
-    // Output info
+    // Remove expired nodes
     $this->output()->writeln('Removing expired..');
     $this->removeExpiredNodes();
 

--- a/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
+++ b/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
@@ -215,9 +215,6 @@ class SyncContent extends DrushCommands {
 
     // Output info
     $this->output()->writeln('Removing expired..');
-
-    // Remove expired nodes
-    $this->output()->writeln('Removing expired..');
     $this->removeExpiredNodes();
 
     // Form message for the event


### PR DESCRIPTION
#### Changes
Added handling to in_languages field.  field_in_language was existing string field in Drupal. The field is now changed to entity reverence (taxonomy).

##### How to test
- Test with branch https://github.com/City-of-Helsinki/employment-services-ui/pull/348
- `drush edel node --bundle=event`
-  `drush linkedevents:sync`
- `drush sapi-rt`
-  `drush sapi-i`
-  Check that you have new taxonomy terms [terms](https://drupal-tyollisyyspalvelut-helfi.docker.so/sv/admin/structure/taxonomy/manage/event_languages/overview)
- Check also that translation are in place (in this case all Finnish) 
- run commands above again and check that you don't have duplicate terms
- After running commands move to the PR https://github.com/City-of-Helsinki/employment-services-ui/pull/348
