### PR TITLE
THF-535: add field super event

### DIFF
--- a/conf/cmi/core.entity_form_display.node.event.default.yml
+++ b/conf/cmi/core.entity_form_display.node.event.default.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.event.field_short_description
     - field.field.node.event.field_start_time
     - field.field.node.event.field_street_address
+    - field.field.node.event.field_super_event
     - field.field.node.event.field_tags
     - field.field.node.event.field_text
     - node.type.event
@@ -193,6 +194,14 @@ content:
   field_street_address:
     type: string_textfield
     weight: 23
+    region: content
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  field_super_event:
+    type: string_textfield
+    weight: 35
     region: content
     settings:
       size: 60

--- a/conf/cmi/core.entity_view_display.node.event.default.yml
+++ b/conf/cmi/core.entity_view_display.node.event.default.yml
@@ -23,6 +23,7 @@ dependencies:
     - field.field.node.event.field_short_description
     - field.field.node.event.field_start_time
     - field.field.node.event.field_street_address
+    - field.field.node.event.field_super_event
     - field.field.node.event.field_tags
     - field.field.node.event.field_text
     - node.type.event
@@ -61,6 +62,14 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 3
+    region: content
+  field_super_event:
+    type: string
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    weight: 4
     region: content
   field_provider:
     type: string

--- a/conf/cmi/core.entity_view_display.node.event.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.event.teaser.yml
@@ -24,6 +24,7 @@ dependencies:
     - field.field.node.event.field_short_description
     - field.field.node.event.field_start_time
     - field.field.node.event.field_street_address
+    - field.field.node.event.field_super_event
     - field.field.node.event.field_tags
     - field.field.node.event.field_text
     - node.type.event
@@ -60,6 +61,7 @@ hidden:
   field_short_description: true
   field_start_time: true
   field_street_address: true
+  field_super_event: true
   field_tags: true
   field_text: true
   langcode: true

--- a/conf/cmi/field.field.node.event.field_super_event.yml
+++ b/conf/cmi/field.field.node.event.field_super_event.yml
@@ -1,0 +1,19 @@
+uuid: 3f7acc65-e602-4680-b979-0354cea35796
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_super_event
+    - node.type.event
+id: node.event.field_super_event
+field_name: field_super_event
+entity_type: node
+bundle: event
+label: 'Super event'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/conf/cmi/field.storage.node.field_super_event.yml
+++ b/conf/cmi/field.storage.node.field_super_event.yml
@@ -1,0 +1,21 @@
+uuid: 5b10c33a-b4e5-47b1-88ed-06954dbfa654
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_super_event
+field_name: field_super_event
+entity_type: node
+type: string
+settings:
+  max_length: 255
+  case_sensitive: false
+  is_ascii: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
+++ b/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
@@ -449,6 +449,7 @@ class SyncContent extends DrushCommands {
     $node->field_location_extra_info = $source->location_extra_info->$langcode ?? $source->location_extra_info->fi ?? '';
     $node->field_street_address = $source->location->street_address->$langcode ?? $source->location->street_address->fi ?? '';
     $node->field_provider = $source->provider->$langcode ?? $source->provider->fi ?? '';
+    $node->field_super_event = $source->super_event->{'@id'} ?? '' ;
 
     // Hardcode tags to finnish for now.
     $node->field_tags = $this->getTags($source->keywords, 'fi');


### PR DESCRIPTION
Added field super event

#### testing
- run with branch `THF-535-super-event-ui`
- `make drush-cim; drush-cr;`
- Check from Drupal site that the Event content type has field field_super_event
- `make shell`
- `drush edel node --bundle=event`
-  `drush sapi-i`
- `drush sapi-rt`
- `drush linkedevents:sync; `
-  If the event has super_event you should have the super_event url in the super_event field- All languages
- Check that you don't get errors to the console.
- Check the code.