### PR TITLE
THF-529: Handle duplicate and removed events

### DIFF
--- a/conf/cmi/views.view.event_content.yml
+++ b/conf/cmi/views.view.event_content.yml
@@ -3,6 +3,7 @@ langcode: fi
 status: true
 dependencies:
   config:
+    - field.storage.node.field_id
     - node.type.event
   module:
     - node
@@ -61,6 +62,69 @@ display:
           type: string
           settings:
             link_to_entity: true
+        field_id:
+          id: field_id
+          table: node__field_id
+          field: field_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: field
+          label: id
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: false
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         type:
           id: type
           table: node_field_data
@@ -383,6 +447,50 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        field_id_value:
+          id: field_id_value
+          table: node__field_id
+          field: field_id_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          operator: '='
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: field_id_value_op
+            label: ID
+            description: ''
+            use_operator: false
+            operator: field_id_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: field_id_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+              jsonapi: '0'
+              nextjs: '0'
+              editor: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
         type:
           id: type
           table: node_field_data
@@ -636,7 +744,8 @@ display:
         - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_id'
   page_event:
     id: page_event
     display_title: Events
@@ -670,4 +779,5 @@ display:
         - user
         - 'user.node_grants:view'
         - user.permissions
-      tags: {  }
+      tags:
+        - 'config:field.storage.node.field_id'


### PR DESCRIPTION
**To test**
- Checkout branch, run `make drush-cim drush-cr`
- Check the events content list: https://drupal-tyollisyyspalvelut-helfi.docker.so/admin/content/event
  - The "ID" field should be visible in the table and as a filter
- Edit an event node and change the ID to something that doesn't match a real event ID
- Run the linkedevents sync command: `drush linkedevents:sync`
- The event you modified should now be unpublished
- Read code changes




 