### PR TITLE
DRAFT: THF-567: fix disabled hero field from visibility

### DIFF
--- a/public/modules/custom/tyollisyyspalvelut_common/tyollisyyspalvelut_common.module
+++ b/public/modules/custom/tyollisyyspalvelut_common/tyollisyyspalvelut_common.module
@@ -110,3 +110,15 @@ function tyollisyyspalvelut_common_pathauto_pattern_alter(\Drupal\pathauto\Patha
     }
   }
 }
+
+/**
+ * Implements hook_form_alter().
+ */
+function tyollisyyspalvelut_common_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
+  if (in_array($form_id, ['node_page_form', 'node_page_edit_form'])) {
+    var_dump($form['field_hero']);
+    if (!empty($form['field_hero']['#states']) && empty($form['field_hero']['#type'])) {
+      $form['field_hero']['#states'] = [];
+    }
+  }
+}

--- a/public/modules/custom/tyollisyyspalvelut_common/tyollisyyspalvelut_common.module
+++ b/public/modules/custom/tyollisyyspalvelut_common/tyollisyyspalvelut_common.module
@@ -116,7 +116,6 @@ function tyollisyyspalvelut_common_pathauto_pattern_alter(\Drupal\pathauto\Patha
  */
 function tyollisyyspalvelut_common_form_alter(array &$form, FormStateInterface $form_state, string $form_id): void {
   if (in_array($form_id, ['node_page_form', 'node_page_edit_form'])) {
-    var_dump($form['field_hero']);
     if (!empty($form['field_hero']['#states']) && empty($form['field_hero']['#type'])) {
       $form['field_hero']['#states'] = [];
     }


### PR DESCRIPTION
### The problem

Hero field is disabled from basic page. But some reason Drupal brings` #states` for `field_hero` even if I completely delete the hero fields from Drupal. 

{ ["#states"]=> array(1) { ["visible"]=> array(1) { [":input[name="field_has_hero[value]"]"]=> array(1) { ["checked"]=> bool(true) } } } }


### Solution proposal

We make hook_form_alter and empty the states if the field doesn't have '#type'

