### PR TITLE
THF-618: fix duple tags and node null

### DIFF
--- a/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
+++ b/public/modules/custom/tyollisyyspalvelut_linkedevents/src/Commands/SyncContent.php
@@ -373,7 +373,12 @@ class SyncContent extends DrushCommands {
       $keywords[] = $value;
     }
     foreach ($source->audience as $value) {
-      $keywords[] = $value;
+     if (in_array($value, $keywords)) {
+       continue;
+     }
+     else {
+       $keywords[] = $value;
+     }
     }
 
     foreach ($keywords as $keyword) {
@@ -693,7 +698,7 @@ class SyncContent extends DrushCommands {
     foreach ($ids as $id) {
       /** @var \Drupal\node\NodeInterface $node */
       $node = $this->nodeStorage->load($id);
-      if (!$node->hasField('field_id') || $node->get('field_id')->isEmpty()) {
+      if (!$node instanceof \Drupal\node\NodeInterface || !$node->hasField('field_id') || $node->get('field_id')->isEmpty()) {
         continue;
       }
 


### PR DESCRIPTION
### fixed

- immigrants and young people tags are coming 2 times
- sync not working.

#### Testing

##### step 1
- Check the events content list: https://drupal-tyollisyyspalvelut-helfi.docker.so/admin/content/event
- The "ID" field should be visible in the table and as a filter
- Edit an event node and change the ID to something that doesn't match a real event ID

##### step 2
- Run the linkedevents sync command: drush linkedevents:sync
- you should now get any errors
- The event you modified should now be unpublished
- Read code changes

##### step 3
- drush edel node --bundle=event
- drush linkedevents:sync
- drush search-api:clear; drush search-api:rebuild-tracker; drush search-api:index; drush cr;
- check on event page that you don't have any events which have 2 times immigrants or young people tag.