### PR TITLE
THF-453: THF-453: add field field_search_keyword_text and add it to i…

### DIFF
--- a/conf/cmi/core.entity_form_display.node.article.default.yml
+++ b/conf/cmi/core.entity_form_display.node.article.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.article.field_lead
     - field.field.node.article.field_liftup_image
     - field.field.node.article.field_metatags
+    - field.field.node.article.field_search_keyword_text
     - field.field.node.article.field_search_keywords
     - node.type.article
   module:
@@ -29,7 +30,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 7
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -41,7 +42,7 @@ content:
     third_party_settings: {  }
   field_content:
     type: paragraphs
-    weight: 5
+    weight: 6
     region: content
     settings:
       title: Paragraph
@@ -74,11 +75,19 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 19
+    weight: 20
     region: content
     settings:
       sidebar: false
       use_details: true
+    third_party_settings: {  }
+  field_search_keyword_text:
+    type: string_textarea
+    weight: 5
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
     third_party_settings: {  }
   field_search_keywords:
     type: entity_reference_autocomplete_tags
@@ -99,49 +108,49 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 11
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 9
+    weight: 10
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 16
+    weight: 17
     region: content
     settings: {  }
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 12
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 15
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   simple_sitemap:
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 13
+    weight: 14
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 10
+    weight: 11
     region: content
     settings:
       display_label: true
@@ -155,13 +164,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 6
+    weight: 7
     region: content
     settings:
       match_operator: CONTAINS
@@ -171,12 +180,12 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 17
+    weight: 18
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 18
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_form_display.node.landing_page.default.yml
+++ b/conf/cmi/core.entity_form_display.node.landing_page.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.landing_page.field_liftup_image
     - field.field.node.landing_page.field_metatags
     - field.field.node.landing_page.field_notification
+    - field.field.node.landing_page.field_search_keyword_text
     - field.field.node.landing_page.field_search_keywords
     - node.type.landing_page
   module:
@@ -48,13 +49,13 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 8
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   field_content:
     type: paragraphs
-    weight: 17
+    weight: 18
     region: content
     settings:
       title: Paragraph
@@ -106,7 +107,7 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 10
+    weight: 11
     region: content
     settings:
       sidebar: false
@@ -137,6 +138,14 @@ content:
         delete_confirmation: false
         split_text: false
         show_drag_and_drop: false
+  field_search_keyword_text:
+    type: string_textarea
+    weight: 7
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
   field_search_keywords:
     type: entity_reference_autocomplete_tags
     weight: 6
@@ -156,49 +165,49 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 15
+    weight: 16
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 11
+    weight: 12
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   publish_on:
     type: datetime_timestamp_no_default
-    weight: 19
+    weight: 20
     region: content
     settings: {  }
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 12
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   scheduler_settings:
-    weight: 18
+    weight: 19
     region: content
     settings: {  }
     third_party_settings: {  }
   simple_sitemap:
-    weight: 14
+    weight: 15
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 16
+    weight: 17
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 13
+    weight: 14
     region: content
     settings:
       display_label: true
@@ -212,13 +221,13 @@ content:
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 9
+    weight: 10
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 7
+    weight: 8
     region: content
     settings:
       match_operator: CONTAINS
@@ -228,12 +237,12 @@ content:
     third_party_settings: {  }
   unpublish_on:
     type: datetime_timestamp_no_default
-    weight: 20
+    weight: 21
     region: content
     settings: {  }
     third_party_settings: {  }
   url_redirects:
-    weight: 21
+    weight: 22
     region: content
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_form_display.node.page.default.yml
+++ b/conf/cmi/core.entity_form_display.node.page.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.page.field_lower_content
     - field.field.node.page.field_metatags
     - field.field.node.page.field_notification
+    - field.field.node.page.field_search_keyword_text
     - field.field.node.page.field_search_keywords
     - field.field.node.page.field_sidebar_content
     - node.type.page
@@ -52,7 +53,7 @@ mode: default
 content:
   created:
     type: datetime_timestamp
-    weight: 9
+    weight: 8
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -77,28 +78,28 @@ content:
     third_party_settings: {  }
   field_hide_navigation:
     type: boolean_checkbox
-    weight: 4
+    weight: 3
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_hide_search:
     type: boolean_checkbox
-    weight: 5
+    weight: 4
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_hide_sidebar:
     type: boolean_checkbox
-    weight: 3
+    weight: 2
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   field_lead_in:
     type: string_textarea
-    weight: 17
+    weight: 16
     region: content
     settings:
       rows: 3
@@ -125,7 +126,7 @@ content:
     third_party_settings: {  }
   field_metatags:
     type: metatag_firehose
-    weight: 7
+    weight: 6
     region: content
     settings:
       sidebar: false
@@ -156,9 +157,17 @@ content:
         delete_confirmation: false
         split_text: false
         show_drag_and_drop: false
+  field_search_keyword_text:
+    type: string_textarea
+    weight: 18
+    region: content
+    settings:
+      rows: 5
+      placeholder: ''
+    third_party_settings: {  }
   field_search_keywords:
     type: entity_reference_autocomplete_tags
-    weight: 18
+    weight: 17
     region: content
     settings:
       match_operator: CONTAINS
@@ -194,13 +203,13 @@ content:
     third_party_settings: {  }
   path:
     type: path
-    weight: 14
+    weight: 13
     region: content
     settings: {  }
     third_party_settings: {  }
   promote:
     type: boolean_checkbox
-    weight: 11
+    weight: 10
     region: content
     settings:
       display_label: true
@@ -213,7 +222,7 @@ content:
     third_party_settings: {  }
   published_at:
     type: publication_date_timestamp
-    weight: 13
+    weight: 12
     region: content
     settings: {  }
     third_party_settings: {  }
@@ -223,40 +232,40 @@ content:
     settings: {  }
     third_party_settings: {  }
   simple_sitemap:
-    weight: 15
+    weight: 14
     region: content
     settings: {  }
     third_party_settings: {  }
   status:
     type: boolean_checkbox
-    weight: 16
+    weight: 15
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   sticky:
     type: boolean_checkbox
-    weight: 12
+    weight: 11
     region: content
     settings:
       display_label: true
     third_party_settings: {  }
   title:
     type: string_textfield
-    weight: 6
+    weight: 5
     region: content
     settings:
       size: 60
       placeholder: ''
     third_party_settings: {  }
   translation:
-    weight: 10
+    weight: 9
     region: content
     settings: {  }
     third_party_settings: {  }
   uid:
     type: entity_reference_autocomplete
-    weight: 8
+    weight: 7
     region: content
     settings:
       match_operator: CONTAINS

--- a/conf/cmi/core.entity_view_display.node.article.default.yml
+++ b/conf/cmi/core.entity_view_display.node.article.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.article.field_lead
     - field.field.node.article.field_liftup_image
     - field.field.node.article.field_metatags
+    - field.field.node.article.field_search_keyword_text
     - field.field.node.article.field_search_keywords
     - node.type.article
   module:
@@ -19,6 +20,13 @@ targetEntityType: node
 bundle: article
 mode: default
 content:
+  field_search_keyword_text:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }

--- a/conf/cmi/core.entity_view_display.node.landing_page.default.yml
+++ b/conf/cmi/core.entity_view_display.node.landing_page.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.landing_page.field_liftup_image
     - field.field.node.landing_page.field_metatags
     - field.field.node.landing_page.field_notification
+    - field.field.node.landing_page.field_search_keyword_text
     - field.field.node.landing_page.field_search_keywords
     - node.type.landing_page
   module:
@@ -38,6 +39,13 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_search_keyword_text:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 4
     region: content
   field_search_keywords:
     type: entity_reference_label

--- a/conf/cmi/core.entity_view_display.node.page.default.yml
+++ b/conf/cmi/core.entity_view_display.node.page.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.page.field_lower_content
     - field.field.node.page.field_metatags
     - field.field.node.page.field_notification
+    - field.field.node.page.field_search_keyword_text
     - field.field.node.page.field_search_keywords
     - field.field.node.page.field_sidebar_content
     - node.type.page
@@ -43,6 +44,13 @@ content:
       link: ''
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_search_keyword_text:
+    type: basic_string
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
     region: content
   links:
     settings: {  }

--- a/conf/cmi/core.entity_view_display.node.page.search_index.yml
+++ b/conf/cmi/core.entity_view_display.node.page.search_index.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.page.field_lower_content
     - field.field.node.page.field_metatags
     - field.field.node.page.field_notification
+    - field.field.node.page.field_search_keyword_text
     - field.field.node.page.field_search_keywords
     - field.field.node.page.field_sidebar_content
     - node.type.page
@@ -42,6 +43,7 @@ hidden:
   field_lower_content: true
   field_metatags: true
   field_notification: true
+  field_search_keyword_text: true
   field_search_keywords: true
   field_sidebar_content: true
   langcode: true

--- a/conf/cmi/field.field.node.article.field_search_keyword_text.yml
+++ b/conf/cmi/field.field.node.article.field_search_keyword_text.yml
@@ -1,0 +1,19 @@
+uuid: 3b0150ab-7ff4-4602-9d56-daddb1cb72da
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_search_keyword_text
+    - node.type.article
+id: node.article.field_search_keyword_text
+field_name: field_search_keyword_text
+entity_type: node
+bundle: article
+label: 'Search keyword text'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/conf/cmi/field.field.node.landing_page.field_search_keyword_text.yml
+++ b/conf/cmi/field.field.node.landing_page.field_search_keyword_text.yml
@@ -1,0 +1,19 @@
+uuid: fac3ca14-76d9-4919-a18c-0f602423dc65
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_search_keyword_text
+    - node.type.landing_page
+id: node.landing_page.field_search_keyword_text
+field_name: field_search_keyword_text
+entity_type: node
+bundle: landing_page
+label: 'Search keyword text'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/conf/cmi/field.field.node.page.field_search_keyword_text.yml
+++ b/conf/cmi/field.field.node.page.field_search_keyword_text.yml
@@ -1,0 +1,19 @@
+uuid: 6961191f-51a0-4ade-84d3-56737fab0fdc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_search_keyword_text
+    - node.type.page
+id: node.page.field_search_keyword_text
+field_name: field_search_keyword_text
+entity_type: node
+bundle: page
+label: 'Search keyword text'
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string_long

--- a/conf/cmi/field.storage.node.field_search_keyword_text.yml
+++ b/conf/cmi/field.storage.node.field_search_keyword_text.yml
@@ -1,0 +1,19 @@
+uuid: 27e0dadf-4721-45e4-8b42-4ba861172416
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_search_keyword_text
+field_name: field_search_keyword_text
+entity_type: node
+type: string_long
+settings:
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/search_api.index.articles_en.yml
+++ b/conf/cmi/search_api.index.articles_en.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.storage.paragraph.field_accordion_title
     - field.storage.node.field_lead
     - field.storage.node.field_search_keywords
+    - field.storage.node.field_search_keyword_text
     - search_api.server.elastic
   module:
     - node
@@ -72,6 +73,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_lead
+  field_search_keyword_text:
+    label: 'Search keyword text'
+    datasource_id: 'entity:node'
+    property_path: field_search_keyword_text
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_search_keyword_text
   field_search_keywords:
     label: 'Search keywords » Taxonomy term » Name'
     datasource_id: 'entity:node'
@@ -142,6 +151,7 @@ processor_settings:
       - field_accordion_title
       - field_article_category
       - field_lead_in
+      - field_search_keyword_text
       - field_search_keywords
       - field_text
       - title

--- a/conf/cmi/search_api.index.articles_fi.yml
+++ b/conf/cmi/search_api.index.articles_fi.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.storage.paragraph.field_accordion_title
     - field.storage.node.field_lead
     - field.storage.node.field_search_keywords
+    - field.storage.node.field_search_keyword_text
     - search_api.server.elastic
   module:
     - node
@@ -72,6 +73,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_lead
+  field_search_keyword_text:
+    label: 'Search keyword text'
+    datasource_id: 'entity:node'
+    property_path: field_search_keyword_text
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_search_keyword_text
   field_search_keywords:
     label: 'Search keywords » Taxonomy term » Name'
     datasource_id: 'entity:node'
@@ -142,6 +151,7 @@ processor_settings:
       - field_accordion_title
       - field_article_category
       - field_lead_in
+      - field_search_keyword_text
       - field_search_keywords
       - field_text
       - title

--- a/conf/cmi/search_api.index.articles_sv.yml
+++ b/conf/cmi/search_api.index.articles_sv.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.storage.paragraph.field_accordion_title
     - field.storage.node.field_lead
     - field.storage.node.field_search_keywords
+    - field.storage.node.field_search_keyword_text
     - search_api.server.elastic
   module:
     - node
@@ -72,6 +73,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_lead
+  field_search_keyword_text:
+    label: 'Search keyword text'
+    datasource_id: 'entity:node'
+    property_path: field_search_keyword_text
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_search_keyword_text
   field_search_keywords:
     label: 'Search keywords » Taxonomy term » Name'
     datasource_id: 'entity:node'
@@ -142,6 +151,7 @@ processor_settings:
       - field_accordion_title
       - field_article_category
       - field_lead_in
+      - field_search_keyword_text
       - field_search_keywords
       - field_text
       - title

--- a/conf/cmi/search_api.index.landings_en.yml
+++ b/conf/cmi/search_api.index.landings_en.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_hero
     - field.storage.paragraph.field_hero_desc
     - field.storage.node.field_search_keywords
+    - field.storage.node.field_search_keyword_text
     - search_api.server.elastic
   module:
     - node
@@ -32,6 +33,14 @@ field_settings:
         - field.storage.paragraph.field_hero_desc
       module:
         - paragraphs
+  field_search_keyword_text:
+    label: 'Search keyword text'
+    datasource_id: 'entity:node'
+    property_path: field_search_keyword_text
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_search_keyword_text
   field_search_keywords:
     label: 'Search keywords » Taxonomy term » Name'
     datasource_id: 'entity:node'
@@ -87,6 +96,7 @@ processor_settings:
     fields:
       - entity_type
       - field_lead_in
+      - field_search_keyword_text
       - field_search_keywords
       - title
       - type

--- a/conf/cmi/search_api.index.landings_fi.yml
+++ b/conf/cmi/search_api.index.landings_fi.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_hero
     - field.storage.paragraph.field_hero_desc
     - field.storage.node.field_search_keywords
+    - field.storage.node.field_search_keyword_text
     - search_api.server.elastic
   module:
     - node
@@ -32,6 +33,14 @@ field_settings:
         - field.storage.paragraph.field_hero_desc
       module:
         - paragraphs
+  field_search_keyword_text:
+    label: 'Search keyword text'
+    datasource_id: 'entity:node'
+    property_path: field_search_keyword_text
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_search_keyword_text
   field_search_keywords:
     label: 'Search keywords » Taxonomy term » Name'
     datasource_id: 'entity:node'
@@ -87,6 +96,7 @@ processor_settings:
     fields:
       - entity_type
       - field_lead_in
+      - field_search_keyword_text
       - field_search_keywords
       - title
       - type

--- a/conf/cmi/search_api.index.landings_sv.yml
+++ b/conf/cmi/search_api.index.landings_sv.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_hero
     - field.storage.paragraph.field_hero_desc
     - field.storage.node.field_search_keywords
+    - field.storage.node.field_search_keyword_text
     - search_api.server.elastic
   module:
     - node
@@ -32,6 +33,14 @@ field_settings:
         - field.storage.paragraph.field_hero_desc
       module:
         - paragraphs
+  field_search_keyword_text:
+    label: 'Search keyword text'
+    datasource_id: 'entity:node'
+    property_path: field_search_keyword_text
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_search_keyword_text
   field_search_keywords:
     label: 'Search keywords » Taxonomy term » Name'
     datasource_id: 'entity:node'
@@ -87,6 +96,7 @@ processor_settings:
     fields:
       - entity_type
       - field_lead_in
+      - field_search_keyword_text
       - field_search_keywords
       - title
       - type

--- a/conf/cmi/search_api.index.pages_en.yml
+++ b/conf/cmi/search_api.index.pages_en.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_hide_search
     - field.storage.node.field_lead_in
     - field.storage.node.field_search_keywords
+    - field.storage.node.field_search_keyword_text
     - field.storage.node.field_content
     - field.storage.paragraph.field_banner_desc
     - field.storage.paragraph.field_accordion_item_content
@@ -116,6 +117,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_lead_in
+  field_search_keyword_text:
+    label: 'Search keyword text'
+    datasource_id: 'entity:node'
+    property_path: field_search_keyword_text
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_search_keyword_text
   field_search_keywords:
     label: 'Search keywords » Taxonomy term » Name'
     datasource_id: 'entity:node'
@@ -188,6 +197,7 @@ processor_settings:
       - field_banner_text
       - field_banner_title
       - field_lead_in
+      - field_search_keyword_text
       - field_search_keywords
       - field_text
       - title

--- a/conf/cmi/search_api.index.pages_fi.yml
+++ b/conf/cmi/search_api.index.pages_fi.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_hide_search
     - field.storage.node.field_lead_in
     - field.storage.node.field_search_keywords
+    - field.storage.node.field_search_keyword_text
     - field.storage.node.field_content
     - field.storage.paragraph.field_banner_desc
     - field.storage.paragraph.field_accordion_item_content
@@ -116,6 +117,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_lead_in
+  field_search_keyword_text:
+    label: 'Search keyword text'
+    datasource_id: 'entity:node'
+    property_path: field_search_keyword_text
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_search_keyword_text
   field_search_keywords:
     label: 'Search keywords » Taxonomy term » Name'
     datasource_id: 'entity:node'
@@ -188,6 +197,7 @@ processor_settings:
       - field_banner_text
       - field_banner_title
       - field_lead_in
+      - field_search_keyword_text
       - field_search_keywords
       - field_text
       - title

--- a/conf/cmi/search_api.index.pages_sv.yml
+++ b/conf/cmi/search_api.index.pages_sv.yml
@@ -6,6 +6,7 @@ dependencies:
     - field.storage.node.field_hide_search
     - field.storage.node.field_lead_in
     - field.storage.node.field_search_keywords
+    - field.storage.node.field_search_keyword_text
     - field.storage.node.field_content
     - field.storage.paragraph.field_banner_desc
     - field.storage.paragraph.field_accordion_item_content
@@ -116,6 +117,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_lead_in
+  field_search_keyword_text:
+    label: 'Search keyword text'
+    datasource_id: 'entity:node'
+    property_path: field_search_keyword_text
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_search_keyword_text
   field_search_keywords:
     label: 'Search keywords » Taxonomy term » Name'
     datasource_id: 'entity:node'
@@ -188,6 +197,7 @@ processor_settings:
       - field_banner_text
       - field_banner_title
       - field_lead_in
+      - field_search_keyword_text
       - field_search_keywords
       - field_text
       - title


### PR DESCRIPTION
#### Changes


Added field_search_keyword_text all content types where we have field_search_keywords. Then added the field_search_keyword_text to all indexes that have field_search_keywords

#### Testing

- Test with fronted branch 
- `make drush-cim; make drush-cr;`

##### Test1 
- Create new taxonomy filed https://drupal-tyollisyyspalvelut-helfi.docker.so/admin/structure/taxonomy/manage/search_keywords/add
- give the field name Porkkana
- Create 1 content where you have Porkkana in keywords
- Create 1 content where you have Porkkana as keyword_text
- You should have the content first in list that has the keywords and second the one that has the Porkkana as keyword_text. All the other content witch contains the word Porkkana should be below the new contents you created.

##### Test 2
- Add more words to content where you have Porkkana as keyword_text. Add example "Työ". You should get almost 70 search result and your content should be top of the list.

##### Test 3

- Try search with some event title and compare with production site: Example title CV - työpaja. In production you should get other content first and then the events and local site you should get events first.

