### PR TITLE
Thf 622 short news event index

### DIFF
--- a/conf/cmi/search_api.index.articles_en.yml
+++ b/conf/cmi/search_api.index.articles_en.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_article_category
     - field.storage.node.field_content
+    - field.storage.paragraph.field_accordion_description
     - field.storage.paragraph.field_accordion_text
     - field.storage.paragraph.field_text
     - field.storage.paragraph.field_accordion_title
@@ -15,6 +16,7 @@ dependencies:
   module:
     - node
     - paragraphs
+    - publication_date
     - taxonomy
     - search_api
 id: articles_en
@@ -30,10 +32,29 @@ field_settings:
     dependencies:
       module:
         - node
+  created:
+    label: 'Authored on'
+    datasource_id: 'entity:node'
+    property_path: created
+    type: date
+    dependencies:
+      module:
+        - node
   entity_type:
     label: 'Entity type'
     property_path: search_api_entity_type
     type: string
+  field_accordion_description:
+    label: 'Content region » Paragraph » Description'
+    datasource_id: 'entity:node'
+    property_path: 'field_content:entity:field_accordion_description'
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_content
+        - field.storage.paragraph.field_accordion_description
+      module:
+        - paragraphs
   field_accordion_text:
     label: 'Content region » Paragraph » Text'
     datasource_id: 'entity:node'
@@ -102,6 +123,14 @@ field_settings:
         - field.storage.paragraph.field_text
       module:
         - paragraphs
+  published_at:
+    label: 'Published on'
+    datasource_id: 'entity:node'
+    property_path: published_at
+    type: date
+    dependencies:
+      module:
+        - publication_date
   title:
     label: Title
     datasource_id: 'entity:node'
@@ -147,6 +176,7 @@ processor_settings:
     all_fields: true
     fields:
       - entity_type
+      - field_accordion_description
       - field_accordion_text
       - field_accordion_title
       - field_article_category

--- a/conf/cmi/search_api.index.articles_fi.yml
+++ b/conf/cmi/search_api.index.articles_fi.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_article_category
     - field.storage.node.field_content
+    - field.storage.paragraph.field_events_list_desc
     - field.storage.paragraph.field_accordion_text
     - field.storage.paragraph.field_text
     - field.storage.paragraph.field_accordion_title
@@ -15,6 +16,7 @@ dependencies:
   module:
     - node
     - paragraphs
+    - publication_date
     - taxonomy
     - search_api
 id: articles_fi
@@ -26,6 +28,14 @@ field_settings:
     label: Changed
     datasource_id: 'entity:node'
     property_path: changed
+    type: date
+    dependencies:
+      module:
+        - node
+  created:
+    label: 'Authored on'
+    datasource_id: 'entity:node'
+    property_path: created
     type: date
     dependencies:
       module:
@@ -64,6 +74,17 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_article_category
+  field_events_list_desc:
+    label: 'Content region » Paragraph » Description'
+    datasource_id: 'entity:node'
+    property_path: 'field_content:entity:field_events_list_desc'
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_content
+        - field.storage.paragraph.field_events_list_desc
+      module:
+        - paragraphs
   field_lead_in:
     label: Lead
     datasource_id: 'entity:node'
@@ -102,20 +123,20 @@ field_settings:
         - field.storage.paragraph.field_text
       module:
         - paragraphs
+  published_at:
+    label: 'Published on'
+    datasource_id: 'entity:node'
+    property_path: published_at
+    type: date
+    dependencies:
+      module:
+        - publication_date
   title:
     label: Title
     datasource_id: 'entity:node'
     property_path: title
     type: text
     boost: !!float 2
-    dependencies:
-      module:
-        - node
-  type:
-    label: 'Content type'
-    datasource_id: 'entity:node'
-    property_path: type
-    type: string
     dependencies:
       module:
         - node
@@ -150,12 +171,12 @@ processor_settings:
       - field_accordion_text
       - field_accordion_title
       - field_article_category
+      - field_events_list_desc
       - field_lead_in
       - field_search_keyword_text
       - field_search_keywords
       - field_text
       - title
-      - type
       - url
     title: true
     alt: true

--- a/conf/cmi/search_api.index.articles_sv.yml
+++ b/conf/cmi/search_api.index.articles_sv.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.storage.node.field_article_category
     - field.storage.node.field_content
+    - field.storage.paragraph.field_accordion_description
     - field.storage.paragraph.field_accordion_text
     - field.storage.paragraph.field_text
     - field.storage.paragraph.field_accordion_title
@@ -15,6 +16,7 @@ dependencies:
   module:
     - node
     - paragraphs
+    - publication_date
     - taxonomy
     - search_api
 id: articles_sv
@@ -30,10 +32,29 @@ field_settings:
     dependencies:
       module:
         - node
+  created:
+    label: 'Authored on'
+    datasource_id: 'entity:node'
+    property_path: created
+    type: date
+    dependencies:
+      module:
+        - node
   entity_type:
     label: 'Entity type'
     property_path: search_api_entity_type
     type: string
+  field_accordion_description:
+    label: 'Content region » Paragraph » Description'
+    datasource_id: 'entity:node'
+    property_path: 'field_content:entity:field_accordion_description'
+    type: text
+    dependencies:
+      config:
+        - field.storage.node.field_content
+        - field.storage.paragraph.field_accordion_description
+      module:
+        - paragraphs
   field_accordion_text:
     label: 'Content region » Paragraph » Text'
     datasource_id: 'entity:node'
@@ -102,6 +123,14 @@ field_settings:
         - field.storage.paragraph.field_text
       module:
         - paragraphs
+  published_at:
+    label: 'Published on'
+    datasource_id: 'entity:node'
+    property_path: published_at
+    type: date
+    dependencies:
+      module:
+        - publication_date
   title:
     label: Title
     datasource_id: 'entity:node'
@@ -147,6 +176,7 @@ processor_settings:
     all_fields: true
     fields:
       - entity_type
+      - field_accordion_description
       - field_accordion_text
       - field_accordion_title
       - field_article_category

--- a/conf/cmi/search_api.index.events_en.yml
+++ b/conf/cmi/search_api.index.events_en.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.storage.node.field_in_language
     - field.storage.node.field_location
     - field.storage.node.field_location_extra_info
+    - field.storage.node.field_location_id
     - field.storage.node.field_short_description
     - field.storage.node.field_start_time
     - field.storage.node.field_street_address
@@ -106,6 +107,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_location_extra_info
+  field_location_id:
+    label: 'Location ID'
+    datasource_id: 'entity:node'
+    property_path: field_location_id
+    type: integer
+    dependencies:
+      config:
+        - field.storage.node.field_location_id
   field_start_time:
     label: 'Start time'
     datasource_id: 'entity:node'

--- a/conf/cmi/search_api.index.events_fi.yml
+++ b/conf/cmi/search_api.index.events_fi.yml
@@ -12,6 +12,7 @@ dependencies:
     - field.storage.node.field_in_language
     - field.storage.node.field_location
     - field.storage.node.field_location_extra_info
+    - field.storage.node.field_location_id
     - field.storage.node.field_short_description
     - field.storage.node.field_start_time
     - field.storage.node.field_street_address
@@ -115,6 +116,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_location_extra_info
+  field_location_id:
+    label: 'Location ID'
+    datasource_id: 'entity:node'
+    property_path: field_location_id
+    type: integer
+    dependencies:
+      config:
+        - field.storage.node.field_location_id
   field_start_time:
     label: 'Start time'
     datasource_id: 'entity:node'

--- a/conf/cmi/search_api.index.events_sv.yml
+++ b/conf/cmi/search_api.index.events_sv.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.storage.node.field_in_language
     - field.storage.node.field_location
     - field.storage.node.field_location_extra_info
+    - field.storage.node.field_location_id
     - field.storage.node.field_short_description
     - field.storage.node.field_start_time
     - field.storage.node.field_street_address
@@ -106,6 +107,14 @@ field_settings:
     dependencies:
       config:
         - field.storage.node.field_location_extra_info
+  field_location_id:
+    label: 'Location ID'
+    datasource_id: 'entity:node'
+    property_path: field_location_id
+    type: integer
+    dependencies:
+      config:
+        - field.storage.node.field_location_id
   field_start_time:
     label: 'Start time'
     datasource_id: 'entity:node'

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,16 +1,18 @@
-version: "2.2"
+version: "3.7"
 services:
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.15.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.4.0
     container_name: tyollisyyspalvelut_es
     environment:
       - discovery.type=single-node
+      - xpack.security.enabled=false
     ports:
       - 9200:9200
       - 9300:9300
     networks:
       - internal
       - stonehenge-network
+
 
 networks:
   elastic:

--- a/public/modules/custom/tyollisyyspalvelut_elasticsearch/src/EventSubscriber/PrepareIndexSubscriber.php
+++ b/public/modules/custom/tyollisyyspalvelut_elasticsearch/src/EventSubscriber/PrepareIndexSubscriber.php
@@ -66,7 +66,7 @@ class PrepareIndexSubscriber implements EventSubscriberInterface {
     $filter_name = $stemmer_language . '_stop';
     $filter_language = '_' . $stemmer_language . '_';
 
-    if ($langcode === 'fi') {
+    if (isset($langcode) && $langcode === 'fi') {
       $indexConfig["body"]["settings"]["index"] = [
         "analysis" => [
           "analyzer" => [


### PR DESCRIPTION
#### Changes:

Updated Elasticsearch to version 8.4.0.
Added new fields to the Elasticsearch index.

#### Testing:

##### Docker:

-` make up`
- `make drush-cim`
-` make drush-cr`.


##### Docker Container Check:

- Verify that the running Elasticsearch container is now using version 8.4.0.
- Remove the old Elasticsearch container:
- Find the old container IDs with `docker ps -a`.
- Delete a container with `docker rm <container_id>`.
- List images with `docker images`.
- Delete old Elasticsearch images using `docker rmi <image_id>`.


##### Index Rebuild:

- Rebuild the Elasticsearch index.
```
drush search-api:clear
drush search-api:rebuild-tracker
drush search-api:index
drush cr
UI Branch 
```Check:

Check the changes in the code and then move to the UI branch: https://github.com/City-of-Helsinki/employment-services-ui/pull/381

